### PR TITLE
refactor: make FormSelect generic and remove data duplication

### DIFF
--- a/src/app/(user)/ingredients/create/page.tsx
+++ b/src/app/(user)/ingredients/create/page.tsx
@@ -37,7 +37,7 @@ const Page = async () => {
     // Transform suppliers for the select options
     const supplierOptions = result?.suppliers?.map((supplier) => ({
         id: supplier.id,
-        name: supplier.name,
+        name: supplier.name
     })) ?? [];
 
     return (

--- a/src/app/components/ingredients/ingredientForm.tsx
+++ b/src/app/components/ingredients/ingredientForm.tsx
@@ -17,7 +17,6 @@ import { categoryOptions, unitOptions } from './ingredientsFormComponents/select
 import { Tag, Scale, Truck } from 'lucide-react';
 import Modal from '../shared/modal';
 import ItemsStore from '../shared/itemsStore';
-import MultipleSelect from '../shared/multipleSelect';
 import { SelectableItem } from '../shared/SelectStore';
 
 type AddIngredientProps = {
@@ -77,6 +76,8 @@ const IngredientForm = ({ ingredient, mode, userId, supplierOptions}: AddIngredi
                icon={Tag}
                register={register}
                onKeyDown={handleKeyDown}
+               getValue={(opt) => opt.value}
+               getLabel={(opt) => opt.name}
              />
           </div>
 
@@ -94,6 +95,8 @@ const IngredientForm = ({ ingredient, mode, userId, supplierOptions}: AddIngredi
                icon={Scale}
                register={register}
                onKeyDown={handleKeyDown}
+               getValue={(opt) => opt.id}
+               getLabel={(opt) => opt.name}
              />
           </div>
         
@@ -124,6 +127,8 @@ const IngredientForm = ({ ingredient, mode, userId, supplierOptions}: AddIngredi
                icon={Scale}
                register={register}
                onKeyDown={handleKeyDown}
+               getValue={(opt) => opt.value}
+               getLabel={(opt) => opt.name}
              />
           </div>
 

--- a/src/app/components/ingredients/ingredientsFormComponents/FormSelect.tsx
+++ b/src/app/components/ingredients/ingredientsFormComponents/FormSelect.tsx
@@ -18,7 +18,8 @@ interface FormSelectProps <T extends Record<string, any>> {
   icon: LucideIcon;
   register: UseFormRegister<IngredientFormFields>;
   onKeyDown: (e: React.KeyboardEvent<HTMLSelectElement>) => void;
-  value: string[] | number[]
+  getValue: (option: T) => string;
+  getLabel: (option: T) => string;
 };
 
 const FormSelect = <T extends Record<string, any>>({ 
@@ -27,8 +28,9 @@ const FormSelect = <T extends Record<string, any>>({
   placeholder, 
   icon: Icon, 
   register, 
-  onKeyDown ,
-  value
+  onKeyDown,
+  getValue,
+  getLabel 
 }: FormSelectProps<T>) => (
   <div className={`
     flex items-center w-full px-4 h-12
@@ -58,8 +60,8 @@ const FormSelect = <T extends Record<string, any>>({
     >
       <option value="" disabled className="text-gray-400">{placeholder}</option>
       {options.map((option) => (
-        <option key={option.value} value={option.value}>
-          {option.name}
+        <option key={getValue(option)} value={getValue(option)}>
+          {getLabel(option)}
         </option>
       ))}
     </select>


### PR DESCRIPTION
- Updated FormSelect to support generic option types using accessor functions.
- Introduced 'getValue' and 'getLabel' props to FormSelect for flexible data mapping.
- Removed redundant 'value' property from SelectableItem interface.
- Cleaned up supplier data transformation in ingredients creation page.
- Updated IngredientForm to use the new generic FormSelect implementation.