### PR TITLE
ci: add GitHub Actions gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DATABASE_URL: postgres://ci:ci@localhost:5432/ci
+  AUTH_SECRET: ci-placeholder-secret
+  AUTH_GOOGLE_ID: ci-placeholder
+  AUTH_GOOGLE_SECRET: ci-placeholder
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ github.ref_name }}-
+            turbo-
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec turbo run build test lint --cache-dir=.turbo

--- a/apps/web/src/ci-canary.test.ts
+++ b/apps/web/src/ci-canary.test.ts
@@ -1,3 +1,0 @@
-test('ci canary: must never land on main', () => {
-  expect(true).toBe(false);
-});

--- a/apps/web/src/ci-canary.test.ts
+++ b/apps/web/src/ci-canary.test.ts
@@ -1,0 +1,3 @@
+test('ci canary: must never land on main', () => {
+  expect(true).toBe(false);
+});

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -41,6 +41,21 @@ header, with its reasoning stated — the bar is high (novel architecture
 or judgment-dense work a plan cannot make executor-safe), and Fable 5
 states the call outright either way.
 
+**Executor modes and checkpoints:** every plan is executed in one of two
+modes, and the plan's header says which applies by default:
+- **Supervised** — a subagent dispatched by Fable 5 in-session; Fable 5
+  reviews between plan tasks, no extra ceremony needed.
+- **External** — any executor whose work Fable 5 cannot observe live
+  (another session, another harness, e.g. Gemini on Antigravity). Git is
+  the ONLY visible surface, so external executors MUST: (1) commit at
+  every plan task boundary as the plans already require, AND push after
+  every such commit; (2) paste the verification-gate output (test/build
+  results, grep results) into the commit body so review needs no replay;
+  (3) tick the plan file's `- [ ]` checkboxes in the same commit;
+  (4) STOP at any step marked `⛔ CHECKPOINT` — push, report, and wait
+  for review by Panos or Fable 5 before continuing. Proceeding past a
+  checkpoint unreviewed is a plan violation even if everything is green.
+
 **TDD rule:** the canonical definition is the
 `superpowers:test-driven-development` skill — its Iron Law applies: no
 production code without a failing test first; code written before its

--- a/docs/superpowers/plans/2026-08-23-ci-pipeline.md
+++ b/docs/superpowers/plans/2026-08-23-ci-pipeline.md
@@ -5,6 +5,8 @@
 > **Authority note (docs/AGENTS.md Delivery Process):** authored by Fable 5; executors implement as written and STOP on anything the plan doesn't cover.
 >
 > **TDD note:** this task is a declared configuration exception (spec, Decision 7). No new tests; the gate is the workflow running green on a real PR.
+>
+> **Executor mode:** supervised or external (docs/AGENTS.md, "Executor modes"). External executors: push every task-boundary commit with gate output in the commit body and tick the plan checkboxes in the same commit. This plan needs no mid-run `⛔ CHECKPOINT` — the PR opened in Task 3 IS the visible review surface, and its green→red(canary)→green check history is the evidence.
 
 **Goal:** Gate every PR to `main` with `turbo run build test lint` in GitHub Actions.
 

--- a/docs/superpowers/plans/2026-08-23-task2-hono-api.md
+++ b/docs/superpowers/plans/2026-08-23-task2-hono-api.md
@@ -5,6 +5,8 @@
 > **Authority (docs/AGENTS.md):** authored by Fable 5; executors implement as written, STOP-and-report on anything uncovered. **Execution: executor models** — Fable 5 judged this task not super-complex.
 >
 > **TDD:** Tasks 3–10 are behavioral — strict red-green per `superpowers:test-driven-development`; every test is watched failing first. Task 2 (domain extraction) is a **declared refactor exception**: no new tests; gate = existing suite + build green, zero behavior diff.
+>
+> **Executor mode:** may be run supervised OR external (docs/AGENTS.md, "Executor modes"). External executors: push every task-boundary commit with gate output in the commit body, tick the checkboxes in the same commit, and STOP at each `⛔ CHECKPOINT` below until Panos or Fable 5 reviews the pushed work.
 
 **Goal:** `apps/api` (Hono, port 3001) exposes every web-app operation as a documented `/v1` endpoint; domain layer extracted to `@costwise/domain`; web app unchanged.
 
@@ -76,6 +78,7 @@ and `packages/domain/tsconfig.json` — copy `packages/db/tsconfig.json` exactly
 - [ ] **Step 5:** Wire web: `pnpm --filter web add "@costwise/domain@workspace:*"`; add `"@costwise/domain"` to `transpilePackages` in `apps/web/next.config.ts`. Rewrite web imports of the moved modules — every `@/app/services/X` → `@costwise/domain/services/X` (except `services` itself), `@/app/repositories/X` → `@costwise/domain/repositories/X`, `@/types/X` → `@costwise/domain/types/X` (except `pg`), `@/app/utils/{errors,pricing,transformers}` → `@costwise/domain/utils/...`. Relative-path variants (`../../utils/errors` etc.) too — find with `grep -rn "utils/errors\|utils/pricing\|utils/transformers\|/services/\|/repositories/\|types/specialTypes\|types/repositories\|types/services\|types/context" apps/web/src | grep -v "@costwise" | grep -v "components/"` and iterate until only legitimate hits remain (UI files like `services.ts`, `utils/{cn,formatters,pagination,errorHandler,uiHelpers}` stay web-local).
 - [ ] **Step 6:** Gates: `pnpm install && pnpm build && pnpm test && pnpm lint` all green; `grep -rn "next/" packages/` empty; web dev smoke: recipes/ingredients/suppliers/dashboard pages render, create+delete a recipe works and the list refreshes (revalidatePath relocation proof). Anything failing that Steps 1–5 don't explain: STOP and report.
 - [ ] **Step 7:** Commit: `git add -A && git commit -m "refactor: extract domain layer into @costwise/domain"`.
+- [ ] **Step 8: ⛔ CHECKPOINT — push `feature/hono-api` and stop.** This task rewired the entire web app's imports; it gets reviewed before anything is built on top. Report the gate outputs and wait for Panos/Fable 5 sign-off (external mode) or Fable 5's between-task review (supervised).
 
 ---
 
@@ -390,6 +393,8 @@ app.route("/v1", v1);
 ```
 
 `index.ts` wires real services: `makeRecipeService: (userId) => new RecipeService(userId)` (import from `@costwise/domain/services/recipeService`). Verify GREEN; workspace gates green. Commit `feat(api): /v1/recipes endpoints`.
+
+- [ ] **⛔ CHECKPOINT — push and stop.** This task established THE TEMPLATE that Tasks 6–9 mass-produce. A flaw here multiplies by four domains; it gets reviewed before replication.
 
 ---
 


### PR DESCRIPTION
Adds the ci workflow per docs/superpowers/specs/2026-08-23-ci-pipeline-design.md: pnpm install (frozen lockfile) + turbo run build test lint with placeholder env, pnpm/turbo caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)