### PR TITLE
docs: one writer per checkout rule for external executors

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -56,6 +56,13 @@ modes, and the plan's header says which applies by default:
   for review by Panos or Fable 5 before continuing. Proceeding past a
   checkpoint unreviewed is a plan violation even if everything is green.
 
+**One writer per checkout:** an external executor MUST work in its own
+clone or `git worktree` (`git worktree add ../costwise-<task> main`),
+never in a directory another session is using. Two sessions sharing one
+checkout switch branches under each other and commits land on the wrong
+branch (this happened on 2026-08-23 during the CI task). The remote is
+the only shared surface.
+
 **TDD rule:** the canonical definition is the
 `superpowers:test-driven-development` skill — its Iron Law applies: no
 production code without a failing test first; code written before its


### PR DESCRIPTION
Adds the one-writer-per-checkout rule to the Delivery Process after the 2026-08-23 incident where an external executor and a Fable 5 session shared this working directory during the CI task and commits landed on the wrong branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)