### PR TITLE
docs: Task 5 — deploy the split (spec + plan)

### DIFF
--- a/docs/superpowers/plans/2026-08-23-task5-deploy-split.md
+++ b/docs/superpowers/plans/2026-08-23-task5-deploy-split.md
@@ -31,6 +31,7 @@
 
 - [ ] `git fetch origin && git merge-base --is-ancestor origin/fix/ingredient-supplier-selection origin/main && echo BUGFIX-MERGED` — informational only; note the result (the deploy ships whatever `main` holds; urgent bug 868kv84c1 should ideally be merged first — STOP and report if it isn't, don't wait silently).
 - [ ] Own clone/worktree, clean tree, branch `feature/deploy-split` off pulled `origin/main`.
+- [ ] Check ClickUp 868kv87ad (Google sign-in error-page flash): if still unclassified at cutover time, flag it at the Task 4 checkpoint — an unclassified auth flash makes a Task 8 Google-login failure ambiguous between the pre-existing bug and the new split-origin config. Panos decides whether to classify it first or proceed.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-23-task5-deploy-split.md
+++ b/docs/superpowers/plans/2026-08-23-task5-deploy-split.md
@@ -1,0 +1,184 @@
+# Task 5 — Deploy the Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans. Checkbox steps track progress.
+>
+> **Authority (docs/AGENTS.md):** authored by Fable 5; executors implement as written, STOP-and-report on anything uncovered. **Execution: executor models for Tasks 1–3 (repo changes), in their own clone/worktree. Tasks 5–8 are Panos actions** (they need his Railway/Vercel/Google/DNS accounts) — the executor's job there is to verify and record outcomes, never to guess at dashboard state.
+>
+> **Executor mode:** external allowed — push every task-boundary commit with gate output in the body, tick checkboxes in the same commit, STOP at every `⛔ CHECKPOINT`.
+>
+> **TDD:** entire delta is deployment configuration — declared config exception per spec Decision 10. Every commit gates on `pnpm build && pnpm test && pnpm lint`; the behavioral gates are the deployed `/health` check and the Task 8 walkthrough.
+
+**Goal:** `apps/api` live on Railway at `https://api.<apex>`, web on Vercel at `https://app.<apex>`, sessions working across both, production walkthrough green.
+
+**Architecture:** Railway runs the API as a long-lived Node process via `tsx` (no Dockerfile; `railway.json` at repo root pins install/start/healthcheck). Cookies become cross-subdomain via Better Auth `advanced.crossSubDomainCookies`, gated on a new `COOKIE_DOMAIN` env var so dev is untouched. Vercel just gains env vars + a custom domain and a rebuild (NEXT_PUBLIC_* is build-time inlined).
+
+**Tech Stack:** Railway (Railpack builder), Vercel, Better Auth 1.7, Hono/@hono/node-server, tsx.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-task5-deploy-split-design.md`
+**ClickUp:** https://app.clickup.com/t/868kv7tad
+
+## Global Constraints
+
+- `<apex>` below is a placeholder for the production apex domain Panos names at the Task 4 checkpoint. Web origin = `https://app.<apex>`, API origin = `https://api.<apex>`, cookie domain = `.<apex>`. Substitute everywhere; never ship a placeholder.
+- Local dev behavior must not change: no `COOKIE_DOMAIN` set locally, port fallback stays 3001, `pnpm dev` untouched.
+- Env inventory is spec Decision 6's table — no extra vars, none skipped.
+- Cutover order is spec Decision 8: code merged → API healthy → Google URI → Vercel envs/domain → web redeploy → walkthrough.
+- Workspace gates (`pnpm build && pnpm test && pnpm lint`) green at every commit.
+
+---
+
+### Task 1: Preflight (executor)
+
+- [ ] `git fetch origin && git merge-base --is-ancestor origin/fix/ingredient-supplier-selection origin/main && echo BUGFIX-MERGED` — informational only; note the result (the deploy ships whatever `main` holds; urgent bug 868kv84c1 should ideally be merged first — STOP and report if it isn't, don't wait silently).
+- [ ] Own clone/worktree, clean tree, branch `feature/deploy-split` off pulled `origin/main`.
+
+---
+
+### Task 2: API production runtime (executor)
+
+**Files:**
+- Modify: `apps/api/src/index.ts` (port line only)
+- Modify: `apps/api/package.json` (start script; tsx → dependencies)
+- Create: `railway.json` (repo root)
+- Modify: `turbo.json` (globalEnv)
+
+**Interfaces produced:** `pnpm --filter api start` boots the server honoring `PORT`; Railway reads `railway.json` for build/deploy config.
+
+- [ ] **Step 1:** In `apps/api/src/index.ts`, change the final `serve(...)` call to:
+
+```ts
+serve(
+  { fetch: createApp(deps).fetch, port: Number(process.env.PORT ?? 3001) },
+  (i) => console.log(`api listening on :${i.port}`)
+);
+```
+
+- [ ] **Step 2:** In `apps/api/package.json`: add `"start": "tsx src/index.ts"` to `scripts`; move `"tsx": "^4.20.3"` from `devDependencies` to `dependencies`. Run `pnpm install` (lockfile updates).
+
+- [ ] **Step 3:** Create `railway.json` at the repo root:
+
+```json
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "buildCommand": "pnpm install --frozen-lockfile"
+  },
+  "deploy": {
+    "startCommand": "pnpm --filter api start",
+    "healthcheckPath": "/health",
+    "restartPolicyType": "ON_FAILURE"
+  }
+}
+```
+
+- [ ] **Step 4:** In `turbo.json`, extend `globalEnv` (keep existing entries, append): `"NEXT_PUBLIC_WEB_ORIGIN"`, `"COOKIE_DOMAIN"`, `"PORT"`.
+
+- [ ] **Step 5:** Verify locally:
+
+```bash
+pnpm build && pnpm test && pnpm lint
+PORT=3999 pnpm --filter api start
+```
+
+Expected: gates green; server logs `api listening on :3999`; `curl -s localhost:3999/health` → `{"status":"ok"}`. Ctrl-C the server. Then confirm no dev regression: `pnpm --filter api dev` still listens on :3001.
+
+- [ ] **Step 6:** Commit (gate output in body) and push:
+
+```bash
+git add apps/api/src/index.ts apps/api/package.json railway.json turbo.json pnpm-lock.yaml
+git commit -m "feat(api): production runtime — PORT env, start script, railway.json"
+git push -u origin feature/deploy-split
+```
+
+---
+
+### Task 3: Cross-subdomain cookies (executor)
+
+**Files:**
+- Modify: `apps/api/src/auth.ts`
+
+**Interfaces produced:** setting `COOKIE_DOMAIN=.<apex>` on the API host scopes Better Auth cookies to the apex; unset → today's behavior exactly.
+
+- [ ] **Step 1:** In `apps/api/src/auth.ts`, add to the `betterAuth({ ... })` options object (sibling of `trustedOrigins`):
+
+```ts
+  advanced: {
+    ...(process.env.COOKIE_DOMAIN
+      ? {
+          crossSubDomainCookies: {
+            enabled: true,
+            domain: process.env.COOKIE_DOMAIN,
+          },
+        }
+      : {}),
+  },
+```
+
+If the installed `better-auth` types reject this shape, STOP and report the actual type — do not guess an alternative key.
+
+- [ ] **Step 2:** Gates: `pnpm build && pnpm test && pnpm lint` → green. Quick behavioral probe (dev unchanged): `pnpm dev`, sign in locally, confirm the session cookie in devtools has **no** Domain attribute (host-only cookie, as today). Stop dev servers.
+
+- [ ] **Step 3:** Commit + push:
+
+```bash
+git add apps/api/src/auth.ts
+git commit -m "feat(api): opt-in cross-subdomain session cookies via COOKIE_DOMAIN"
+git push
+```
+
+---
+
+### Task 4: PR + ⛔ CHECKPOINT (executor opens; Panos decides)
+
+- [ ] Open a PR `feature/deploy-split` → `main` titled "Task 5: deploy-split runtime + cookie config", body linking the spec, this plan, and ClickUp 868kv7tad.
+- [ ] ⛔ **CHECKPOINT — do not proceed until Panos has:** (1) approved the spec (Decisions 1–2 especially: Railway; custom apex required); (2) named the apex domain `<apex>` (owned or purchased, with DNS access); (3) confirmed a Railway account on a non-sleeping plan; (4) reviewed + merged the PR. Record the concrete `<apex>` value in the PR thread — all later steps substitute it.
+
+---
+
+### Task 5: Railway service (Panos, guided)
+
+- [ ] In Railway: New Project → Deploy from GitHub repo → `st9ho3/chat-agent`, branch `main`. Leave root at the repo root (`railway.json` is read from there).
+- [ ] Service → Variables — set exactly (spec Decision 6):
+  `DATABASE_URL` (same value as today's `.env`), `BETTER_AUTH_SECRET` (fresh: `openssl rand -base64 32`), `BETTER_AUTH_URL=https://api.<apex>`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `WEB_ORIGIN=https://app.<apex>`, `COOKIE_DOMAIN=.<apex>`, `BLOB_READ_WRITE_TOKEN` (Vercel → Storage → Blob store token), `NODE_ENV=production`.
+- [ ] Deploy; open the build log. Verify: Railpack uses Node ≥ 20 and pnpm 11 (from `packageManager`), runs `pnpm install --frozen-lockfile`, and the deploy log shows `api listening on :<railway port>` with the health check passing. STOP-and-report on any builder misdetection.
+- [ ] Settings → Networking → Custom Domain: `api.<apex>`; add the CNAME Railway shows at the DNS provider. Wait for the domain to verify.
+- [ ] Verify from any machine:
+
+```bash
+curl -s https://api.<apex>/health
+```
+
+Expected: `{"status":"ok"}`. Also open `https://api.<apex>/docs` — the API reference renders. An unauthenticated `curl -s https://api.<apex>/v1/recipes` returns the 401 envelope.
+
+---
+
+### Task 6: Google Console redirect URI (Panos)
+
+- [ ] Google Cloud Console → the existing CostWise OAuth client → Authorized redirect URIs → **add** `https://api.<apex>/v1/auth/callback/google`. Keep the existing localhost URI (dev still uses it). Save.
+
+---
+
+### Task 7: Vercel cutover (Panos, guided)
+
+- [ ] Vercel project `chat-agent` → Settings → Environment Variables → **Production**: `NEXT_PUBLIC_API_URL=https://api.<apex>`, `NEXT_PUBLIC_WEB_ORIGIN=https://app.<apex>`.
+- [ ] Settings → Domains: add `app.<apex>`; create the CNAME/A records Vercel shows at the DNS provider; wait for verification.
+- [ ] **Redeploy production** (Deployments → latest `main` → Redeploy) — required, the env vars are inlined at build time. Wait for the deployment to go Ready.
+- [ ] Sanity: open `https://app.<apex>` — the signin page loads; in devtools Network, the page's fetches target `https://api.<apex>` (no `localhost:3001` anywhere). If a `localhost` URL appears, the env vars weren't picked up — STOP, re-check Task 7 step 1, redeploy.
+
+---
+
+### Task 8: Production walkthrough — acceptance gate (Panos; executor records)
+
+Run on `https://app.<apex>`, devtools open (Console + Network):
+
+- [ ] **Credential login** with an existing user → lands authenticated; in devtools → Application → Cookies, the session cookie's Domain is `.<apex>`; hard-refresh an authenticated page → still signed in (RSC cookie forwarding works).
+- [ ] **Google login** (second browser/profile) → completes and returns to `https://app.<apex>`, session works.
+- [ ] Recipes: list, create (with ingredients), edit, delete — values correct.
+- [ ] Ingredients: list, create, edit (incl. supplier selection), delete.
+- [ ] Suppliers: list, create, edit, delete.
+- [ ] Search returns results; dashboard analytics render.
+- [ ] Upload an image on a recipe/ingredient → it renders back from `*.public.blob.vercel-storage.com`.
+- [ ] Console: zero CORS errors across the walkthrough. `curl -s https://api.<apex>/v1/recipes` (no cookie) → 401 envelope.
+- [ ] Sign out → redirected to `/signin`; deep-linking an authenticated route while signed out redirects to `/signin`.
+- [ ] ⛔ **CHECKPOINT — walkthrough verdict.** All green: move ClickUp 868kv7tad → done, note the two production URLs on the task. Any failure: file findings against this plan and STOP (rollback if user-facing: Vercel instant-rollback to the prior deployment; the Railway service can be stopped — spec Decision 8).

--- a/docs/superpowers/plans/2026-08-23-task5-deploy-split.md
+++ b/docs/superpowers/plans/2026-08-23-task5-deploy-split.md
@@ -138,7 +138,7 @@ git push
 
 ### Task 5: Railway service (Panos, guided)
 
-- [ ] In Railway: New Project → Deploy from GitHub repo → `st9ho3/chat-agent`, branch `main`. Leave root at the repo root (`railway.json` is read from there).
+- [ ] In Railway: New Project → Deploy from GitHub repo → `st9ho3/costwise` (renamed from `chat-agent` on GitHub; the Vercel project keeps the old name), branch `main`. Leave root at the repo root (`railway.json` is read from there).
 - [ ] Service → Variables — set exactly (spec Decision 6):
   `DATABASE_URL` (same value as today's `.env`), `BETTER_AUTH_SECRET` (fresh: `openssl rand -base64 32`), `BETTER_AUTH_URL=https://api.<apex>`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `WEB_ORIGIN=https://app.<apex>`, `COOKIE_DOMAIN=.<apex>`, `BLOB_READ_WRITE_TOKEN` (Vercel → Storage → Blob store token), `NODE_ENV=production`.
 - [ ] Deploy; open the build log. Verify: Railpack uses Node ≥ 20 and pnpm 11 (from `packageManager`), runs `pnpm install --frozen-lockfile`, and the deploy log shows `api listening on :<railway port>` with the health check passing. STOP-and-report on any builder misdetection.

--- a/docs/superpowers/specs/2026-08-23-task5-deploy-split-design.md
+++ b/docs/superpowers/specs/2026-08-23-task5-deploy-split-design.md
@@ -41,7 +41,8 @@ the split origins; the production app passes a full end-to-end walkthrough
 - Postgres: `pg` Pool on `DATABASE_URL`, no pool tuning (default max 10).
   The DB is already remote (dev connects over the internet), so the API host
   only needs the same URL. Parent ADR 10: **Postgres unchanged**.
-- Vercel project **chat-agent** (repo `st9ho3/chat-agent`): Root Directory
+- Vercel project **chat-agent** (repo `st9ho3/costwise`, renamed on GitHub
+  from `chat-agent`): Root Directory
   `apps/web` set, deploys green; **production env vars not set yet**.
 - `/health` returns `{"status":"ok"}` unauthenticated — ready-made health
   check endpoint.

--- a/docs/superpowers/specs/2026-08-23-task5-deploy-split-design.md
+++ b/docs/superpowers/specs/2026-08-23-task5-deploy-split-design.md
@@ -1,0 +1,174 @@
+# Task 5 — Deploy the Split (Spec)
+
+**Date:** 2026-08-23
+**ClickUp:** [Task 5 — Deploy the split](https://app.clickup.com/t/868kv7tad)
+**Parent spec:** `docs/superpowers/specs/2026-08-23-ui-backend-separation-design.md` (ADR 10)
+**Depends on:** Task 4 (merged to main 2026-08-23, PR #163; CI + Vercel checks green)
+**Status:** Spec ready for review. Plan authored alongside (deploy is config-heavy;
+no code dependencies left to wait for).
+**Execution:** executor models for the repo changes (not super-complex — every
+decision is made here; the code delta is ~20 lines of env-driven config).
+Dashboard steps (Railway, Vercel, Google Console, DNS) are **Panos actions**
+guided by the plan's checklists, because they need his accounts.
+
+## Goal
+
+`apps/api` runs as a long-lived Node process on Railway behind HTTPS;
+`apps/web` stays on Vercel and points at it; Better Auth cookies work across
+the split origins; the production app passes a full end-to-end walkthrough
+(login both methods, recipes, ingredients, suppliers, search, uploads).
+
+## Current State (verified 2026-08-23)
+
+- `apps/api` boots via `tsx src/index.ts` (tsx is a **devDependency**); its
+  `build` script is `tsc --noEmit` (typecheck only, nothing emitted); there is
+  **no Dockerfile and no `start` script**; port is **hardcoded 3001**
+  (`serve({ fetch, port: 3001 })` — no hostname given, so Node binds all
+  interfaces, which is what Railway needs).
+- Cross-origin config already env-driven: CORS on `/v1/*` allows
+  `WEB_ORIGIN` with credentials (`apps/api/src/app.ts:115`); Better Auth
+  `baseURL` = `BETTER_AUTH_URL`, `trustedOrigins` = `[WEB_ORIGIN]`
+  (`apps/api/src/auth.ts`). **No cookie-domain / cross-subdomain config
+  exists yet** — dev works because web :3000 and api :3001 share `localhost`.
+- Web reaches the API only via `NEXT_PUBLIC_API_URL` (browser client, RSC
+  helper `apiServer.ts`, `serverSession.ts`, `authClient.ts`) — **build-time
+  inlined**, so changing it requires a Vercel rebuild. Google sign-in's
+  return URL uses `NEXT_PUBLIC_WEB_ORIGIN` (`authButton.tsx:32`), which is
+  **missing from `turbo.json` globalEnv**.
+- Uploads: the API calls `@vercel/blob` `put()` → needs
+  `BLOB_READ_WRITE_TOKEN` on the API host. The blob hostname is already
+  allowed in `apps/web/next.config.ts`.
+- Postgres: `pg` Pool on `DATABASE_URL`, no pool tuning (default max 10).
+  The DB is already remote (dev connects over the internet), so the API host
+  only needs the same URL. Parent ADR 10: **Postgres unchanged**.
+- Vercel project **chat-agent** (repo `st9ho3/chat-agent`): Root Directory
+  `apps/web` set, deploys green; **production env vars not set yet**.
+- `/health` returns `{"status":"ok"}` unauthenticated — ready-made health
+  check endpoint.
+
+## Decisions
+
+1. **API host: Railway** (settles parent ADR 10's open choice).
+   Rationale: deploys a pnpm/Turborepo monorepo from GitHub with **no
+   Dockerfile** (Railpack builder), injects `PORT`, gives HTTPS + custom
+   domains out of the box, supports health-checked always-on services, and
+   the Hobby plan (~$5/mo) never sleeps — sleeping would break the entire
+   premise of this task (long-lived SSE for Task 7's chat).
+   Rejected: **Render** (free tier spins down → cold starts + killed
+   connections; paid tier has no edge over Railway here); **Fly.io**
+   (Dockerfile + `fly.toml` + volume/region ops for no benefit at this
+   scale). Deployment config is committed as `railway.json` at the repo root
+   so the service definition is code, not dashboard state.
+2. **Production domains: one apex, two subdomains — a custom domain is
+   REQUIRED, not optional.** Web = `https://app.<apex>` (Vercel custom
+   domain), API = `https://api.<apex>` (Railway custom domain). This
+   implements Task 3 spec Decision 6. With both hosts under one registrable
+   domain, web→API requests are **same-site**: default Lax cookies flow on
+   credentialed fetches, and Safari/ITP third-party-cookie blocking never
+   enters the picture.
+   Rejected: shipping on `chat-agent.vercel.app` + `*.up.railway.app` — the
+   session cookie would be third-party (and `vercel.app` is on the Public
+   Suffix List, so no shared-domain cookie is even possible); Safari blocks
+   it outright → login broken. **The concrete apex is an input from Panos**
+   (owned or newly bought — ~10€/yr); the plan parameterizes it as
+   `<apex>` and blocks on a ⛔ CHECKPOINT until it's known.
+3. **Cookie config: Better Auth `advanced.crossSubDomainCookies`**, gated on
+   a new env var `COOKIE_DOMAIN` (prod: `.<apex>`; unset in dev, so local
+   behavior is untouched):
+   `advanced: { crossSubDomainCookies: { enabled: true, domain: COOKIE_DOMAIN } }`
+   applied only when `COOKIE_DOMAIN` is set. Secure cookies come free —
+   Better Auth switches them on for https `baseURL`. `trustedOrigins`/CORS
+   keep working off `WEB_ORIGIN` (now `https://app.<apex>`).
+4. **Production runtime: `tsx`, not a compile step.** `tsx` moves to
+   `dependencies`; `apps/api` gains `"start": "tsx src/index.ts"`; Railway
+   runs `pnpm --filter api start`. Rationale: the API consumes workspace
+   packages (`domain`, `db`, `shared`) as raw TS — a `tsc` emit needs
+   project references or a bundler across four packages for zero user-visible
+   benefit at this scale (YAGNI; revisit if cold-start or CPU cost ever
+   matters). `build` stays `tsc --noEmit` as the CI typecheck gate.
+5. **Port from env:** `port: Number(process.env.PORT ?? 3001)` in
+   `apps/api/src/index.ts` — Railway injects `PORT`; 3001 fallback keeps dev
+   identical. Hostname stays unset (Node already binds all interfaces).
+6. **Env inventory** (the complete production set — nothing else):
+
+   | Where | Var | Value |
+   |---|---|---|
+   | Railway | `DATABASE_URL` | same DB as today (unchanged) |
+   | Railway | `BETTER_AUTH_SECRET` | fresh: `openssl rand -base64 32` |
+   | Railway | `BETTER_AUTH_URL` | `https://api.<apex>` |
+   | Railway | `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` | existing Google OAuth client |
+   | Railway | `WEB_ORIGIN` | `https://app.<apex>` |
+   | Railway | `COOKIE_DOMAIN` | `.<apex>` |
+   | Railway | `BLOB_READ_WRITE_TOKEN` | from the existing Vercel Blob store |
+   | Railway | `NODE_ENV` | `production` |
+   | Vercel (Production) | `NEXT_PUBLIC_API_URL` | `https://api.<apex>` |
+   | Vercel (Production) | `NEXT_PUBLIC_WEB_ORIGIN` | `https://app.<apex>` |
+
+   `turbo.json` globalEnv additionally learns `NEXT_PUBLIC_WEB_ORIGIN`,
+   `COOKIE_DOMAIN`, `PORT` (the first is a live gap: turbo-driven prod
+   builds currently strip it).
+7. **Google Console** (Panos action, mirrors Task 3 Decision 9): add
+   redirect URI `https://api.<apex>/v1/auth/callback/google` to the existing
+   OAuth client; keep the localhost URI for dev. No new client.
+8. **Cutover order is load-bearing:** merge code → Railway service healthy on
+   `api.<apex>` → Google URI added → Vercel env vars + `app.<apex>` domain →
+   **redeploy web** (required — `NEXT_PUBLIC_*` is inlined at build) → e2e
+   walkthrough. Rollback = Vercel instant-rollback to the previous
+   deployment + removing the DNS records; the API service can simply be
+   stopped.
+9. **Vercel preview deployments are OUT of this task's acceptance.** They
+   build with preview env (unset → localhost fallbacks) and their origins
+   can't be first-party to the API cookie domain. Acceptance covers the
+   production domain pair only; preview strategy is filed separately if ever
+   wanted.
+10. **TDD posture:** the whole delta is deployment configuration (env
+    plumbing, scripts, `railway.json`) with no branching logic —
+    **declared config exception** per `docs/AGENTS.md`: every commit still
+    gates on `pnpm build && pnpm test && pnpm lint` green, and the
+    behavioral gate is the deployed `/health` check plus the acceptance
+    walkthrough.
+
+## Acceptance Criteria (verification gate)
+
+1. `https://api.<apex>/health` returns `{"status":"ok"}` over HTTPS;
+   `https://api.<apex>/docs` renders the API reference.
+2. `https://app.<apex>` serves the web app from Vercel production.
+3. **Credential login and Google login both work on `https://app.<apex>`**;
+   after login, the session cookie is scoped to `.<apex>` and
+   authenticated pages survive a hard refresh (RSC cookie forwarding
+   works cross-host).
+4. Full walkthrough against production: recipes list/create/edit/delete,
+   ingredients list/create/edit/delete, suppliers list/create/edit/delete,
+   search, dashboard analytics, and an image upload that renders back from
+   blob storage.
+5. Browser console shows no CORS errors during the walkthrough; a `/v1`
+   call without a session returns the 401 envelope.
+6. Sign-out works and signed-out users are redirected to `/signin`.
+7. `pnpm build && pnpm test && pnpm lint` green on the PR; CI green.
+
+## Out of Scope
+
+- Mobile deploy (Task 8); background workers (parent spec §8).
+- Vercel preview-deployment auth strategy (Decision 9).
+- CI → Railway deploy gating (Railway auto-deploys `main`; if we ever want
+  "deploy only after CI", file it separately).
+- Docs sweep — `docs/architecture.md`/`decisions.md` learn the deployed
+  shape in Task 6, not here.
+
+## Risks & Mitigations
+
+- **Wrong/missing env var on either host** → Decision 6's table is the
+  single checklist; the plan verifies each var at the step that consumes it
+  (health check, login, upload).
+- **Railpack build surprises (pnpm workspace)** → `railway.json` pins
+  install + start commands; plan step verifies the build log runs Node ≥20
+  and `pnpm install --frozen-lockfile`; STOP-and-report if the builder
+  misdetects.
+- **Cookie scoped wrong** (forgot `COOKIE_DOMAIN`, or apex typo) → symptom
+  is "login succeeds, next request 401s"; acceptance 3 explicitly inspects
+  the cookie's Domain attribute in devtools before moving on.
+- **Google redirect URI mismatch** → URI added and verified before the web
+  cutover step; the localhost URI stays as fallback for dev.
+- **DNS propagation lag** → plan orders DNS records first among the
+  dashboard steps and gates on `dig`/browser checks before anything
+  depends on them.


### PR DESCRIPTION
Authors the Task 5 spec and implementation plan per the delivery process in `docs/AGENTS.md` (Fable 5 authors; executors execute).

**ClickUp:** https://app.clickup.com/t/868kv7tad
**Spec:** `docs/superpowers/specs/2026-08-23-task5-deploy-split-design.md`
**Plan:** `docs/superpowers/plans/2026-08-23-task5-deploy-split.md`

## Decisions needing your approval (spec Decisions 1–2)
1. **API host: Railway** — no-Dockerfile monorepo deploys, PORT/HTTPS out of the box, always-on Hobby plan (~$5/mo). Render free tier sleeps (kills the long-lived-SSE premise), Fly needs Dockerfile+fly.toml ops.
2. **A custom apex domain is required** — `app.<apex>` (Vercel) + `api.<apex>` (Railway) with cross-subdomain cookies, per Task 3 spec Decision 6. Shipping on `vercel.app` + `railway.app` origins would make the session cookie third-party (Safari blocks it, and vercel.app is on the Public Suffix List). **You need to name the apex** at the plan's Task 4 checkpoint.

Repo code delta the plan prescribes is ~20 lines (PORT env, `start` script, `railway.json`, `COOKIE_DOMAIN`-gated cookie config); all dashboard steps (Railway/Vercel/Google/DNS) are yours, behind ⛔ checkpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)