### PR TITLE
fix(web): Google sign-in returns to the web app, not the API's 404 (868kv87ad)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { Scalar } from "@scalar/hono-api-reference";
 import { errorHandler, defaultHook } from "./middleware/errors";
 import { makeRequireUser } from "./middleware/auth";
+import { authDebug } from "./middleware/authDebug";
 import { recipesRoutes } from "./routes/recipes";
 import { ingredientsRoutes } from "./routes/ingredients";
 import { suppliersRoutes } from "./routes/suppliers";
@@ -116,6 +117,7 @@ export const createApp = (deps: Deps) => {
       credentials: true,
     })
   );
+  app.use("/v1/auth/*", authDebug);
   app.on(["GET", "POST"], "/v1/auth/*", (c) => auth.handler(c.req.raw));
 
   const v1 = new OpenAPIHono<{ Variables: { userId: string } }>({ defaultHook });

--- a/apps/api/src/middleware/authDebug.ts
+++ b/apps/api/src/middleware/authDebug.ts
@@ -1,0 +1,30 @@
+import type { MiddlewareHandler } from "hono";
+
+/**
+ * Diagnostic tracing for the Better Auth surface, off unless AUTH_DEBUG is set.
+ *
+ * Better Auth answers a failed OAuth callback with a 302 to its own HTML error
+ * page (`<basePath>/error?error=<code>`), so the code that explains a failure
+ * is only visible in the Location header of a response we otherwise never see.
+ */
+export const authDebug: MiddlewareHandler = async (c, next) => {
+  if (!process.env.AUTH_DEBUG) return next();
+
+  const started = Date.now();
+  const hadSessionCookie = /better-auth\.session/.test(
+    c.req.header("cookie") ?? ""
+  );
+
+  await next();
+
+  const location = c.res.headers.get("location");
+  const setCookie = c.res.headers.get("set-cookie");
+
+  console.log(
+    `[auth] ${c.req.method} ${new URL(c.req.url).pathname} -> ${c.res.status}` +
+      ` (${Date.now() - started}ms)` +
+      ` cookie-in=${hadSessionCookie ? "session" : "none"}` +
+      ` set-cookie=${setCookie ? setCookie.split("=")[0] : "none"}` +
+      (location ? `\n[auth]   location: ${location}` : "")
+  );
+};

--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -10,6 +10,11 @@ const createJestConfig = nextJest({
 const config: Config = {
   coverageProvider: 'v8',
   testEnvironment: 'jsdom',
+  // mirror the "@/*" -> "./src/*" alias from tsconfig so tests can mock
+  // modules by the same specifier the components import them with
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 }

--- a/apps/web/src/app/components/auth/signInForm.tsx
+++ b/apps/web/src/app/components/auth/signInForm.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { authClient } from '@/app/lib/authClient';
+import { webUrl } from '@/app/lib/webOrigin';
 import useSignIn from '@/app/hooks/useSignIn';
 import { Input } from '../ui/input';
 import { Button } from '../ui/button';
@@ -79,7 +80,7 @@ const SignInForm = () => {
         variant="outline"
         block
         size="lg"
-        onClick={() => authClient.signIn.social({ provider: 'google', callbackURL: '/' })}
+        onClick={() => authClient.signIn.social({ provider: 'google', callbackURL: webUrl('/') })}
         iconLeft={<GoogleIcon />}
       >
         Continue with Google

--- a/apps/web/src/app/components/auth/signUpForm.tsx
+++ b/apps/web/src/app/components/auth/signUpForm.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { authClient } from '@/app/lib/authClient';
+import { webUrl } from '@/app/lib/webOrigin';
 import useSignUp from '@/app/hooks/useSignUp';
 import { Input } from '../ui/input';
 import { Button } from '../ui/button';
@@ -82,7 +83,7 @@ const SignUpForm = () => {
         variant="outline"
         block
         size="lg"
-        onClick={() => authClient.signIn.social({ provider: 'google', callbackURL: '/' })}
+        onClick={() => authClient.signIn.social({ provider: 'google', callbackURL: webUrl('/') })}
         iconLeft={<GoogleIcon />}
       >
         Continue with Google

--- a/apps/web/src/app/components/auth/socialSignIn.test.tsx
+++ b/apps/web/src/app/components/auth/socialSignIn.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+const social = jest.fn()
+
+jest.mock('@/app/lib/authClient', () => ({
+  authClient: {
+    signIn: {
+      social: (...args: unknown[]) => social(...args),
+      email: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), refresh: jest.fn() }),
+}))
+
+import SignInForm from './signInForm'
+import SignUpForm from './signUpForm'
+
+describe('Google sign-in callbackURL', () => {
+  beforeEach(() => social.mockClear())
+
+  // The API lives on its own origin. Better Auth redirects the browser to the
+  // callbackURL verbatim from the callback route, so a relative "/" resolves
+  // against the API host and lands on its 404 instead of the web app.
+  it.each([
+    ['SignInForm', SignInForm],
+    ['SignUpForm', SignUpForm],
+  ])('%s sends an absolute callbackURL to the web origin', (_name, Form) => {
+    render(<Form />)
+    fireEvent.click(screen.getByRole('button', { name: /continue with google/i }))
+
+    expect(social).toHaveBeenCalledTimes(1)
+    const { callbackURL } = social.mock.calls[0][0] as { callbackURL: string }
+    expect(callbackURL).toMatch(/^https?:\/\//)
+    expect(callbackURL.startsWith(window.location.origin)).toBe(true)
+  })
+})

--- a/apps/web/src/app/lib/serverSession.ts
+++ b/apps/web/src/app/lib/serverSession.ts
@@ -9,7 +9,21 @@ export const getServerSession = async (): Promise<{ user: SessionUser } | null> 
     `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001"}/v1/auth/get-session`,
     { headers: { cookie: h.get("cookie") ?? "" }, cache: "no-store" }
   );
-  if (!res.ok) return null;
+  if (!res.ok) {
+    if (process.env.AUTH_DEBUG) {
+      console.log(`[session] get-session -> ${res.status} (treated as signed out)`);
+    }
+    return null;
+  }
   const data = await res.json();
+
+  if (process.env.AUTH_DEBUG) {
+    const cookie = h.get("cookie") ?? "";
+    console.log(
+      `[session] get-session -> 200 user=${data?.user?.id ?? "none"}` +
+        ` cookie-sent=${/better-auth\.session/.test(cookie) ? "session" : "none"}`
+    );
+  }
+
   return data?.user ? { user: data.user } : null;
 };

--- a/apps/web/src/app/lib/webOrigin.ts
+++ b/apps/web/src/app/lib/webOrigin.ts
@@ -1,0 +1,19 @@
+/**
+ * Absolute origin of this web app.
+ *
+ * Auth redirects are performed by the API, which runs on its own origin. Better
+ * Auth stores the callbackURL verbatim and redirects to it from the callback
+ * route, so a relative value like "/" resolves against the API host and lands
+ * on its 404 rather than the app. Every callbackURL must be absolute.
+ *
+ * The browser knows its own origin, so prefer that over configuration it could
+ * disagree with; NEXT_PUBLIC_WEB_ORIGIN only covers server-side rendering.
+ */
+export const webOrigin = (): string => {
+  if (typeof window !== "undefined") return window.location.origin;
+  return process.env.NEXT_PUBLIC_WEB_ORIGIN ?? "http://localhost:3000";
+};
+
+/** Absolute URL for a path within this web app, e.g. redirect targets. */
+export const webUrl = (path: string = "/"): string =>
+  new URL(path, webOrigin()).toString();

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,8 @@
     "AUTH_GOOGLE_SECRET",
     "NEXT_PUBLIC_API_URL",
     "WEB_ORIGIN",
+    "NEXT_PUBLIC_WEB_ORIGIN",
+    "AUTH_DEBUG",
     "NODE_ENV"
   ],
   "tasks": {


### PR DESCRIPTION
Fixes [868kv87ad](https://app.clickup.com/t/868kv87ad) — the error page that flashed after every Google sign-in. **Classified from a real sign-in with tracing, not guessed.**

## Root cause

`signInForm.tsx` and `signUpForm.tsx` passed a literal `callbackURL: '/'`. Better Auth stores the callbackURL verbatim in OAuth state and redirects to it from the callback route — where the browser is sitting on the **API origin**. So `/` resolved to `http://localhost:3001/`, which has no route, and Hono answered with its plain-text 404. That 404 was the flash.

The session cookie is set on that same 302, so login itself always succeeded — which is exactly why the symptom read as "error page, then signed in".

```
GET /v1/auth/callback/google -> 302
  location: /                       <-- before
  location: http://localhost:3000/  <-- after
```

Note: `authButton.tsx`, which reads `NEXT_PUBLIC_WEB_ORIGIN`, is **dead code** and was not the live path — it briefly misdirected the diagnosis. Filed for removal as [868kv8adb](https://app.clickup.com/t/868kv8adb).

## Fix

Both social callers send an absolute URL via a new `webUrl()` helper, derived from `window.location.origin` — the browser cannot disagree with itself about where it is — with `NEXT_PUBLIC_WEB_ORIGIN` only as an SSR fallback. No env configuration can drift out of sync, and preview/prod are correct for free. `WEB_ORIGIN` already matches, so `trustedOrigins` passes unchanged.

## Why this blocks the deploy

After the Task 5 ([868kv7tad](https://app.clickup.com/t/868kv7tad)) domain split, the same redirect would send **every production Google login** to `https://api.<apex>/` → 404. Task 5's acceptance gates on Google login, so this needs to land first.

## Also in this PR

- `AUTH_DEBUG` tracing (`authDebug` middleware + `serverSession` logging), inert unless the env var is set — this is what caught the bug, and it is worth keeping for the production cutover.
- `turbo.json`: add `AUTH_DEBUG` and `NEXT_PUBLIC_WEB_ORIGIN` to `globalEnv`. Turbo's strict env filtering silently drops unlisted vars — proven when `AUTH_DEBUG=1` never reached the api task.
- `jest.config.ts`: map the `@/*` alias so tests can mock modules by the specifier components import.

## Verification

RED test watched failing first (`Received string: "/"`), covering both forms. Then confirmed **live** against a real Google sign-in: callback redirects to `http://localhost:3000/`, session cookie present, `GET / 200` signed in — no 404, no error page, no `/signin` bounce.

Gates: build 6/6, 157 tests, lint clean.

## Not included (deliberate)

No `errorCallbackURL` — a *genuine* OAuth failure still lands on Better Auth's bare error page on the API origin. Real, but a different defect, and unverifiable without inducing an error. Filed as [868kv8jhm](https://app.clickup.com/t/868kv8jhm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)