### PR TITLE
chore(shared,domain): Fallow E — supplier validation logic has one home (868kvw1a8)

### DIFF
--- a/packages/domain/src/services/validationService.ts
+++ b/packages/domain/src/services/validationService.ts
@@ -1,4 +1,5 @@
 import { Ingredient, IngredientSchema } from "@costwise/shared/recipe";
+import { validateComplexEntity as validateComplexEntityWith } from "@costwise/shared/validation";
 
 import { z } from "zod";
 import { ValidationError } from "../utils/errors";
@@ -17,6 +18,11 @@ export const zodValidateIngredientBeforeAddItToDatabase = (
   return validatedIngredient.data;
 };
 
+/**
+ * Domain-facing `validateComplexEntity`: the single implementation lives in
+ * `@costwise/shared/validation`; this wrapper injects `ValidationError` so
+ * failures surface as a 400 with field errors instead of a generic 500.
+ */
 export const validateComplexEntity = <T extends object, TArrayItem>(
   entity: Record<string, unknown>,
   entitySchema: z.ZodType<T, z.ZodTypeDef, unknown>,
@@ -24,45 +30,13 @@ export const validateComplexEntity = <T extends object, TArrayItem>(
   fieldName: string,
   addedItems: TArrayItem[],
   removedItems: TArrayItem[]
-) => {
-  if (fieldName in entity && typeof entity[fieldName] === "string") {
-    entity[fieldName] = new Date(entity[fieldName] as string);
-  }
-  const entityResult = entitySchema.safeParse(entity);
-
-  if (!entityResult.success) {
-    throw new ValidationError(entityResult.error);
-  }
-  const validatedEntity = entityResult.data;
-
-  let validatedAddedItems;
-  let validatedRemovedItems;
-
-  if (addedItems && addedItems.length > 0) {
-    validatedAddedItems = addedItems.map((item: TArrayItem) => {
-      const arrayItem = arraysSchema.safeParse(item);
-
-      if (!arrayItem.success) {
-        throw new ValidationError(arrayItem.error);
-      }
-      return arrayItem.data;
-    });
-  }
-
-  if (removedItems && removedItems.length > 0) {
-    validatedRemovedItems = removedItems.map((item: TArrayItem) => {
-      const arrayItem = arraysSchema.safeParse(item);
-
-      if (!arrayItem.success) {
-        throw new ValidationError(arrayItem.error);
-      }
-      return arrayItem.data;
-    });
-  }
-
-  return {
-    validatedEntity,
-    validatedAddedItems,
-    validatedRemovedItems,
-  };
-};
+) =>
+  validateComplexEntityWith(
+    entity,
+    entitySchema,
+    arraysSchema,
+    fieldName,
+    addedItems,
+    removedItems,
+    (error) => new ValidationError(error)
+  );

--- a/packages/shared/src/transformers.ts
+++ b/packages/shared/src/transformers.ts
@@ -18,8 +18,8 @@ import {
   RawDBSupplier,
   RecipeIngredientFromDB,
 } from "./specialTypes";
-import { normalizePrice } from "./pricing";
-import { z } from "zod";
+import { getDisplayUnit, normalizePrice } from "./pricing";
+import { validateComplexEntity } from "./validation";
 
 export type IngredientFormFields = Ingredient;
 
@@ -169,17 +169,16 @@ export const transformSupplierFromDB = (raw: RawDBSupplier): Supplier => {
   };
 };
 
-export const createIngredientPrototype = (
+/**
+ * Shared body of the create/edit ingredient prototypes — they differ only in
+ * where identity (id, icon, usage) comes from.
+ */
+const buildIngredientPrototype = (
   data: IngredientFormFields,
   confirmedSuppliers: string[],
   userId: string,
+  identity: Pick<Ingredient, "id" | "icon" | "usage">,
 ): Ingredient => {
-  const normalizedUnitPrice = normalizePrice(
-    data.unitPrice,
-    data.unit as Unit,
-    data.quantity,
-  );
-
   const supplierItems = (confirmedSuppliers || []).map((supId) => ({
     suppliersId: supId,
     unit: (data.unit as Unit) || "g",
@@ -188,67 +187,42 @@ export const createIngredientPrototype = (
     isActive: true,
   }));
 
-  const ingredientPrototype: Ingredient = {
-    id: data.id,
-    icon: createIngredientIcon(data.category),
+  return {
+    id: identity.id,
+    icon: identity.icon,
     name: data.name,
-    unit:
-      data.unit === "g" || data.unit === "kg"
-        ? "g"
-        : data.unit === "L" || data.unit === "ml"
-          ? "ml"
-          : "piece",
-    unitPrice: normalizedUnitPrice,
+    unit: getDisplayUnit(data.unit) as Unit,
+    unitPrice: normalizePrice(data.unitPrice, data.unit as Unit, data.quantity),
     quantity: Number(data.quantity) || 1,
-    usage: "0",
+    usage: identity.usage,
     userId: userId,
     category: data.category,
     suppliers: supplierItems,
   };
-  return ingredientPrototype;
 };
+
+export const createIngredientPrototype = (
+  data: IngredientFormFields,
+  confirmedSuppliers: string[],
+  userId: string,
+): Ingredient =>
+  buildIngredientPrototype(data, confirmedSuppliers, userId, {
+    id: data.id,
+    icon: createIngredientIcon(data.category),
+    usage: "0",
+  });
 
 export const createEditIngredientPrototype = (
   data: IngredientFormFields,
   ingredient: Ingredient | IngredientToDisplay,
   confirmedSuppliers: string[],
   userId: string,
-): Ingredient => {
-  const normalizedUnitPrice = normalizePrice(
-    data.unitPrice,
-    data.unit as Unit,
-    data.quantity,
-  );
-
-  const supplierItems = (confirmedSuppliers || []).map((supId) => ({
-    suppliersId: supId,
-    unit: (data.unit as Unit) || "g",
-    quantity: Number(data.quantity) || 1,
-    price: Number(data.unitPrice) || 0,
-    isActive: true,
-  }));
-
-  // Edit mode logic
-  const updatedIngredient: Ingredient = {
+): Ingredient =>
+  buildIngredientPrototype(data, confirmedSuppliers, userId, {
     id: ingredient.id,
     icon: ingredient.icon,
-    name: data.name,
-    unit:
-      data.unit === "g" || data.unit === "kg"
-        ? "g"
-        : data.unit === "L" || data.unit === "ml"
-          ? "ml"
-          : "piece",
-    unitPrice: normalizedUnitPrice,
-    quantity: Number(data.quantity) || 1,
     usage: ingredient.usage || "0",
-    userId: userId,
-    category: data.category,
-    suppliers: supplierItems,
-  };
-
-  return updatedIngredient;
-};
+  });
 
 export const destructureSupplier = (supplier: Supplier) => {
   const dbSupplier: DestructuredSupplier = {
@@ -289,56 +263,6 @@ export const destructureSupplier = (supplier: Supplier) => {
     defaultCurrency: "EUR",
   };
   return { categories, address, financialData, dbSupplier };
-};
-
-export const validateComplexEntity = <T extends object, TArrayItem>(
-  entity: Record<string, unknown>,
-  entitySchema: z.ZodType<T, z.ZodTypeDef, unknown>,
-  arraysSchema: z.ZodType<TArrayItem, z.ZodTypeDef, unknown>,
-  fieldName: string,
-  addedItems: TArrayItem[],
-  removedItems: TArrayItem[]
-) => {
-  if (fieldName in entity && typeof entity[fieldName] === "string") {
-    entity[fieldName] = new Date(entity[fieldName] as string);
-  }
-  const entityResult = entitySchema.safeParse(entity);
-
-  if (!entityResult.success) {
-    throw new Error("Validation failed: " + entityResult.error.message);
-  }
-  const validatedEntity = entityResult.data;
-
-  let validatedAddedItems;
-  let validatedRemovedItems;
-
-  if (addedItems && addedItems.length > 0) {
-    validatedAddedItems = addedItems.map((item: TArrayItem) => {
-      const arrayItem = arraysSchema.safeParse(item);
-
-      if (!arrayItem.success) {
-        throw new Error("Validation failed: " + arrayItem.error.message);
-      }
-      return arrayItem.data;
-    });
-  }
-
-  if (removedItems && removedItems.length > 0) {
-    validatedRemovedItems = removedItems.map((item: TArrayItem) => {
-      const arrayItem = arraysSchema.safeParse(item);
-
-      if (!arrayItem.success) {
-        throw new Error("Validation failed: " + arrayItem.error.message);
-      }
-      return arrayItem.data;
-    });
-  }
-
-  return {
-    validatedEntity,
-    validatedAddedItems,
-    validatedRemovedItems,
-  };
 };
 
 export const prepareSupplierForDB = (

--- a/packages/shared/src/validation.ts
+++ b/packages/shared/src/validation.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+/**
+ * How a validation failure is surfaced. `shared` cannot depend on `domain`, so
+ * callers that need a richer error (e.g. `domain`'s `ValidationError`, which the
+ * API maps to a 400 with field errors) inject their own factory.
+ */
+export type ValidationErrorFactory = (error: z.ZodError) => Error;
+
+const defaultErrorFactory: ValidationErrorFactory = (error) =>
+  new Error("Validation failed: " + error.message);
+
+const validateItems = <TArrayItem>(
+  items: TArrayItem[] | undefined,
+  schema: z.ZodType<TArrayItem, z.ZodTypeDef, unknown>,
+  onError: ValidationErrorFactory,
+): TArrayItem[] | undefined => {
+  if (!items || items.length === 0) {
+    return undefined;
+  }
+
+  return items.map((item) => {
+    const result = schema.safeParse(item);
+
+    if (!result.success) {
+      throw onError(result.error);
+    }
+    return result.data;
+  });
+};
+
+/**
+ * Validates an entity plus the items added to / removed from one of its
+ * collections. `fieldName` names a date field that arrives as a string over the
+ * wire and is revived before parsing.
+ *
+ * Single home for this logic — `domain` wraps it to throw `ValidationError`,
+ * `shared` callers get the default plain `Error`.
+ */
+export const validateComplexEntity = <T extends object, TArrayItem>(
+  entity: Record<string, unknown>,
+  entitySchema: z.ZodType<T, z.ZodTypeDef, unknown>,
+  arraysSchema: z.ZodType<TArrayItem, z.ZodTypeDef, unknown>,
+  fieldName: string,
+  addedItems: TArrayItem[],
+  removedItems: TArrayItem[],
+  onError: ValidationErrorFactory = defaultErrorFactory,
+) => {
+  if (fieldName in entity && typeof entity[fieldName] === "string") {
+    entity[fieldName] = new Date(entity[fieldName] as string);
+  }
+  const entityResult = entitySchema.safeParse(entity);
+
+  if (!entityResult.success) {
+    throw onError(entityResult.error);
+  }
+
+  return {
+    validatedEntity: entityResult.data,
+    validatedAddedItems: validateItems(addedItems, arraysSchema, onError),
+    validatedRemovedItems: validateItems(removedItems, arraysSchema, onError),
+  };
+};


### PR DESCRIPTION
Closes Fallow E (`868kvw1a8`, High) — https://app.clickup.com/t/868kvw1a8

## What was wrong

`validateComplexEntity` existed twice, and the copies had **already diverged**:

| Copy | Consumer | Throws |
|---|---|---|
| `packages/shared/src/transformers.ts` | suppliers, via `prepareSupplierForDB` | `new Error("Validation failed: …")` |
| `packages/domain/src/services/validationService.ts` | recipes, via `recipeService` | `ValidationError` |

`apps/api/src/middleware/errors.ts` only maps `AppError` to a status code, so a supplier validation failure surfaced as a generic 500 while the identical recipe failure returned a 400 with field errors. That is the silent behavior split the finding predicted, already in the code.

## What changed

The single implementation moved to `packages/shared/src/validation.ts` and takes a `ValidationErrorFactory`, since `shared` cannot depend on `domain`. Domain wraps it to inject `ValidationError`.

**No call site changes behavior** — each keeps the exact error type it threw before. Unifying the two error types is a real improvement but a behavior change on an error path, so it is left as a separate call rather than smuggled into a dedup.

Also folds the two intra-file clone pairs the same finding flagged:
- the `addedItems` / `removedItems` validation blocks collapse into one `validateItems()`
- `createIngredientPrototype` and `createEditIngredientPrototype` share one `buildIngredientPrototype` body, differing only in identity (id / icon / usage)

The inline unit ternary in those two is replaced by the existing `getDisplayUnit()`. Identical for every value the `Unit` type permits; the two differed only on an `undefined` unit, where `getDisplayUnit`’s `"g"` now matches what the supplier items in the same function already defaulted to.

## Verification

- `pnpm build`, `pnpm test` (129 tests), `pnpm lint` — green
- `fallow dupes` — no clone group spanning the two files
- duplication **7.4% → 6.0%** (1,057 → 853 lines)

## Follow-up worth filing

Supplier validation failures return 500 where recipes return 400. One line to fix now that the error factory is threaded through, but it changes an API response code, so it should be its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)