### PR TITLE
chore: Fallow A, B, D, I — the low-priority sweep (868kvw0ft, 868kvw0q2, 868kvw157, 868kvw2hr)

### DIFF
--- a/apps/api/src/testing/fakes.ts
+++ b/apps/api/src/testing/fakes.ts
@@ -1,379 +1,48 @@
-import type {
-  Recipe,
-  RecipeIngredients,
-  Ingredient,
-  IngredientToDisplay,
-  Supplier,
-} from "@costwise/shared/recipe";
-import type {
-  RecipeWithQuery,
-  Metadata,
-} from "@costwise/shared/specialTypes";
-import type {
-  CreateRequest,
-  CreateResponse,
-} from "@costwise/domain/types/services";
-import type { SupplierUpdatePayload } from "@costwise/shared/uiTypes";
-import type {
-  RecipeAnalytics,
-  CategoryAnalytics,
-  MarginHighlights,
-  HighImpactIngredient,
-  IngredientAnalytics,
-} from "@costwise/domain/types/repositories";
-import { NotFoundError } from "@costwise/domain/utils/errors";
-import type {
-  Deps,
-  RecipeServiceLike,
-  IngredientServiceLike,
-  SupplierServiceLike,
-  SearchServiceLike,
-  PutBlobFn,
-} from "../app";
+/**
+ * Stable entry point for the API test fakes.
+ *
+ * The per-aggregate detail lives in `recipeFakes.ts`, `ingredientFakes.ts` and
+ * `supplierFakes.ts`, so a schema change touches one file instead of rippling
+ * through every suite that imports from here. Test files import only from this
+ * module.
+ */
+import type { Deps, SearchServiceLike, PutBlobFn } from "../app";
+import { createFakeState } from "./state";
+import { makeRecipeServiceFor } from "./recipeFakes";
+import {
+  makeIngredientServiceFor,
+  toIngredientDisplay,
+} from "./ingredientFakes";
+import { makeSupplierServiceFor } from "./supplierFakes";
 
-export interface FakeState {
-  recipes: Recipe[];
-  recipeDetails: Map<string, RecipeWithQuery>;
-  ingredients: Ingredient[];
-  suppliers: Supplier[];
-  uploadedBlobs: Map<string, { name: string; body: any }>;
-}
-
-const createFakeState = (): FakeState => ({
-  recipes: [],
-  recipeDetails: new Map(),
-  ingredients: [],
-  suppliers: [],
-  uploadedBlobs: new Map(),
-});
-
-export const seedRecipe = (
-  deps: Deps,
-  userId: string,
-  recipe?: Partial<Recipe>,
-  detail?: Partial<RecipeWithQuery>
-) => {
-  const r: Recipe = {
-    id: recipe?.id ?? "11111111-1111-1111-1111-111111111111",
-    title: recipe?.title ?? "Test Recipe",
-    totalCost: recipe?.totalCost ?? 10,
-    createdBy: recipe?.createdBy ?? userId,
-    dateCreated: recipe?.dateCreated ?? new Date(),
-    category: recipe?.category ?? "main",
-    tax: recipe?.tax ?? 0.1,
-    imgPath: recipe?.imgPath ?? "https://example.com/r1.jpg",
-    sellingPrice: recipe?.sellingPrice ?? 15,
-    profitMargin: recipe?.profitMargin ?? 5,
-    foodCost: recipe?.foodCost ?? 8,
-    userId,
-    ...recipe,
-  };
-  const d: RecipeWithQuery = {
-    id: r.id,
-    title: r.title,
-    totalCost: String(r.totalCost),
-    createdBy: r.createdBy,
-    dateCreated: r.dateCreated.toISOString(),
-    category: r.category,
-    tax: String(r.tax),
-    imgPath: r.imgPath,
-    sellingPrice: String(r.sellingPrice ?? 0),
-    profitMargin: String(r.profitMargin ?? 0),
-    foodCost: String(r.foodCost),
-    userId: r.userId,
-    recipeIngredients: [],
-    ...detail,
-  };
-  const state = (deps as any)._state as FakeState;
-  state.recipes.push(r);
-  state.recipeDetails.set(r.id, d);
-  return r;
-};
-
-export const seedIngredient = (
-  deps: Deps,
-  userId: string,
-  ingredient?: Partial<Ingredient>
-) => {
-  const ing: Ingredient = {
-    id: ingredient?.id ?? "44444444-4444-4444-4444-444444444444",
-    icon: ingredient?.icon ?? null,
-    name: ingredient?.name ?? "Flour",
-    unit: ingredient?.unit ?? "kg",
-    unitPrice: ingredient?.unitPrice ?? 1.5,
-    quantity: ingredient?.quantity ?? 10,
-    usage: ingredient?.usage ?? "0",
-    userId,
-    suppliers: ingredient?.suppliers ?? [
-      {
-        suppliersId: "55555555-5555-5555-5555-555555555555",
-        unit: "kg",
-        quantity: 10,
-        price: 15,
-        isActive: true,
-      },
-    ],
-    category: ingredient?.category ?? "5dee106a-5050-443e-8368-03397e02af6d",
-    ...ingredient,
-  };
-  const state = (deps as any)._state as FakeState;
-  state.ingredients.push(ing);
-  return ing;
-};
-
-export const seedSupplier = (
-  deps: Deps,
-  userId: string,
-  supplier?: Partial<Supplier>
-) => {
-  const s: Supplier = {
-    id: supplier?.id ?? "66666666-6666-6666-6666-666666666666",
-    userId,
-    name: supplier?.name ?? "Acme Supplier",
-    icon: supplier?.icon ?? null,
-    category: supplier?.category ?? ["5dee106a-5050-443e-8368-03397e02af6d"],
-    contactPerson: supplier?.contactPerson ?? "John Doe",
-    email: supplier?.email ?? "acme@example.com",
-    phone: supplier?.phone ?? "1234567890",
-    website: supplier?.website ?? "https://acme.com",
-    address: supplier?.address ?? {
-      street: "123 Main St",
-      city: "City",
-      state: "State",
-      postalCode: "12345",
-      country: "Country",
-    },
-    financialData: supplier?.financialData ?? {
-      paymentTerms: "Net 30",
-      vatNumber: "VAT123",
-    },
-    notes: supplier?.notes ?? "Test notes",
-    deliveryTime: supplier?.deliveryTime ?? "1-2 Days",
-    isActive: supplier?.isActive ?? true,
-    dateAdded: supplier?.dateAdded ?? new Date(),
-    ...supplier,
-  };
-  const state = (deps as any)._state as FakeState;
-  state.suppliers.push(s);
-  return s;
-};
+export type { FakeState } from "./state";
+export { seedRecipe } from "./recipeFakes";
+export { seedIngredient } from "./ingredientFakes";
+export { seedSupplier } from "./supplierFakes";
 
 export const fakeDeps = (): Deps => {
   const state = createFakeState();
 
-  const makeRecipeService = (userId: string): RecipeServiceLike => ({
-    async findAll(uId: string, metadata: Metadata) {
-      const userRecipes = state.recipes.filter((r) => r.userId === uId);
-      return {
-        recipes: userRecipes,
-        count: { count: userRecipes.length },
-      };
-    },
-    async findById(id: string) {
-      const detail = state.recipeDetails.get(id);
-      if (!detail || detail.userId !== userId) {
-        throw new NotFoundError("Recipe", id);
-      }
-      return detail;
-    },
-    async create(request: CreateRequest): Promise<CreateResponse> {
-      state.recipes.push(request.recipe);
-      state.recipeDetails.set(request.recipe.id, {
-        id: request.recipe.id,
-        title: request.recipe.title,
-        totalCost: String(request.recipe.totalCost),
-        createdBy: request.recipe.createdBy,
-        dateCreated: request.recipe.dateCreated.toISOString(),
-        category: request.recipe.category,
-        tax: String(request.recipe.tax),
-        imgPath: request.recipe.imgPath,
-        sellingPrice: String(request.recipe.sellingPrice ?? 0),
-        profitMargin: String(request.recipe.profitMargin ?? 0),
-        foodCost: String(request.recipe.foodCost),
-        userId: request.recipe.userId,
-        recipeIngredients: (request.addedIngredients || []).map((ing, idx) => ({
-          id: idx + 1,
-          recipeId: request.recipe.id,
-          ingredientId: ing.ingredientId,
-          quantity: String(ing.quantity),
-          ingredients: {
-            id: ing.ingredientId,
-            name: ing.name,
-            unit: ing.unit,
-            unitPrice: String(ing.unitPrice),
-            quantity: String(ing.quantity),
-            icon: null,
-            usage: "",
-          },
-        })),
-      });
-      return { recipe: request.recipe.id };
-    },
-    async update(
-      id: string,
-      recipe: Recipe,
-      _removed: RecipeIngredients[],
-      _added: RecipeIngredients[]
-    ) {
-      const idx = state.recipes.findIndex(
-        (r) => r.id === id && r.userId === userId
-      );
-      if (idx === -1) {
-        throw new NotFoundError("Recipe", id);
-      }
-      state.recipes[idx] = recipe;
-      return { id };
-    },
-    async delete(id: string) {
-      const idx = state.recipes.findIndex(
-        (r) => r.id === id && r.userId === userId
-      );
-      if (idx === -1) {
-        throw new NotFoundError("Recipe", id);
-      }
-      state.recipes.splice(idx, 1);
-      state.recipeDetails.delete(id);
-      return { id };
-    },
-    async getRecipesAnalytics(uId: string): Promise<RecipeAnalytics> {
-      const userRecipes = state.recipes.filter((r) => r.userId === uId);
-      return {
-        avgProfitMargin: "25",
-        avgFoodCost: "15",
-        totalRecipes: userRecipes.length,
-      };
-    },
-    async getCategoryAnalytics(uId: string): Promise<CategoryAnalytics[]> {
-      return [
-        { category: "starter", count: 1, avgFoodCost: "10" },
-        { category: "main", count: 2, avgFoodCost: "20" },
-      ];
-    },
-    async getMarginHighlights(uId: string): Promise<MarginHighlights> {
-      const userRecipes = state.recipes.filter((r) => r.userId === uId);
-      return {
-        topPerformers: userRecipes,
-        attentionNeeded: [],
-      };
-    },
-  });
-
-  const makeIngredientService = (userId: string): IngredientServiceLike => ({
-    async findAll(uId: string, metadata: Metadata) {
-      const userIngredients = state.ingredients.filter((i) => i.userId === uId);
-      const display: IngredientToDisplay[] = userIngredients.map((i) => {
-        const { suppliers, ...rest } = i;
-        return { ...rest, categoryName: "Produce" as const };
-      });
-      return {
-        ingredients: display,
-        count: { count: display.length },
-      };
-    },
-    async findById(id: string) {
-      const ing = state.ingredients.find(
-        (i) => i.id === id && i.userId === userId
-      );
-      if (!ing) return undefined;
-      const { suppliers, ...rest } = ing;
-      return { ...rest, categoryName: "Produce" as const };
-    },
-    async create(ingredient: Ingredient) {
-      state.ingredients.push(ingredient);
-      return { id: ingredient.id };
-    },
-    async update(ingredient: Ingredient) {
-      const idx = state.ingredients.findIndex(
-        (i) => i.id === ingredient.id && i.userId === userId
-      );
-      if (idx === -1) throw new NotFoundError("Ingredient", ingredient.id);
-      state.ingredients[idx] = ingredient;
-      return { id: ingredient.id };
-    },
-    async delete(id: string) {
-      const idx = state.ingredients.findIndex(
-        (i) => i.id === id && i.userId === userId
-      );
-      if (idx === -1) throw new NotFoundError("Ingredient", id);
-      state.ingredients.splice(idx, 1);
-    },
-    async getIngredientAnalytics(uId: string): Promise<IngredientAnalytics> {
-      const userIngredients = state.ingredients.filter((i) => i.userId === uId);
-      return {
-        totalIngredients: userIngredients.length,
-      };
-    },
-    async getHighImpactIngredients(
-      uId: string,
-      limit: number = 5
-    ): Promise<HighImpactIngredient[]> {
-      const userIngredients = state.ingredients.filter((i) => i.userId === uId);
-      return userIngredients.slice(0, limit).map((i) => ({
-        id: i.id,
-        name: i.name,
-        icon: i.icon ?? null,
-        usage: Number(i.usage) || 0,
-        category: i.category,
-      }));
-    },
-  });
-
-  const makeSupplierService = (userId: string): SupplierServiceLike => ({
-    async findAll(uId: string, metadata: Metadata) {
-      const userSuppliers = state.suppliers.filter((s) => s.userId === uId);
-      return {
-        suppliers: userSuppliers,
-        count: { count: userSuppliers.length },
-      };
-    },
-    async findById(id: string) {
-      const s = state.suppliers.find((s) => s.id === id && s.userId === userId);
-      if (!s) return undefined;
-      return s;
-    },
-    async create(payload: SupplierUpdatePayload) {
-      state.suppliers.push(payload.supplier);
-      return { id: payload.supplier.id };
-    },
-    async update(payload: SupplierUpdatePayload) {
-      const idx = state.suppliers.findIndex(
-        (s) => s.id === payload.supplier.id && s.userId === userId
-      );
-      if (idx === -1) throw new NotFoundError("Supplier", payload.supplier.id);
-      state.suppliers[idx] = payload.supplier;
-      return { id: payload.supplier.id };
-    },
-    async delete(id: string) {
-      const idx = state.suppliers.findIndex(
-        (s) => s.id === id && s.userId === userId
-      );
-      if (idx === -1) throw new NotFoundError("Supplier", id);
-      state.suppliers.splice(idx, 1);
-      return { id };
-    },
-  });
-
+  // Search spans two aggregates, so it stays here rather than in either one.
   const makeSearchService = (
     term: string,
-    userId: string
+    userId: string,
   ): SearchServiceLike => ({
     async findRecipe() {
       return state.recipes.filter(
         (r) =>
           r.userId === userId &&
-          r.title.toLowerCase().includes(term.toLowerCase())
+          r.title.toLowerCase().includes(term.toLowerCase()),
       );
     },
     async findIngredient() {
-      const matching = state.ingredients.filter(
-        (i) =>
-          i.userId === userId &&
-          i.name.toLowerCase().includes(term.toLowerCase())
-      );
-      return matching.map((i) => {
-        const { suppliers, ...rest } = i;
-        return { ...rest, categoryName: "Produce" as const };
-      });
+      return state.ingredients
+        .filter(
+          (i) =>
+            i.userId === userId &&
+            i.name.toLowerCase().includes(term.toLowerCase()),
+        )
+        .map(toIngredientDisplay);
     },
   });
 
@@ -383,9 +52,9 @@ export const fakeDeps = (): Deps => {
   };
 
   const deps: Deps = {
-    makeRecipeService,
-    makeIngredientService,
-    makeSupplierService,
+    makeRecipeService: makeRecipeServiceFor(state),
+    makeIngredientService: makeIngredientServiceFor(state),
+    makeSupplierService: makeSupplierServiceFor(state),
     makeSearchService,
     putBlob,
     getSessionUserId: async (h) => h.get("x-user-id"),

--- a/apps/api/src/testing/ingredientFakes.ts
+++ b/apps/api/src/testing/ingredientFakes.ts
@@ -1,0 +1,109 @@
+import type { Ingredient, IngredientToDisplay } from "@costwise/shared/recipe";
+import type { Metadata } from "@costwise/shared/specialTypes";
+import type {
+  HighImpactIngredient,
+  IngredientAnalytics,
+} from "@costwise/domain/types/repositories";
+import type { Deps, IngredientServiceLike } from "../app";
+import { FakeState, getState, requireOwnedIndex } from "./state";
+
+/** Drops the supplier links and pins a category name, as the read model does. */
+export const toIngredientDisplay = (
+  ingredient: Ingredient,
+): IngredientToDisplay => {
+  const { suppliers, ...rest } = ingredient;
+  return { ...rest, categoryName: "Produce" as const };
+};
+
+export const seedIngredient = (
+  deps: Deps,
+  userId: string,
+  ingredient?: Partial<Ingredient>,
+) => {
+  const ing: Ingredient = {
+    id: ingredient?.id ?? "44444444-4444-4444-4444-444444444444",
+    icon: ingredient?.icon ?? null,
+    name: ingredient?.name ?? "Flour",
+    unit: ingredient?.unit ?? "kg",
+    unitPrice: ingredient?.unitPrice ?? 1.5,
+    quantity: ingredient?.quantity ?? 10,
+    usage: ingredient?.usage ?? "0",
+    userId,
+    suppliers: ingredient?.suppliers ?? [
+      {
+        suppliersId: "55555555-5555-5555-5555-555555555555",
+        unit: "kg",
+        quantity: 10,
+        price: 15,
+        isActive: true,
+      },
+    ],
+    category: ingredient?.category ?? "5dee106a-5050-443e-8368-03397e02af6d",
+    ...ingredient,
+  };
+  getState(deps).ingredients.push(ing);
+  return ing;
+};
+
+export const makeIngredientServiceFor =
+  (state: FakeState) =>
+  (userId: string): IngredientServiceLike => ({
+    async findAll(uId: string, metadata: Metadata) {
+      const display = state.ingredients
+        .filter((i) => i.userId === uId)
+        .map(toIngredientDisplay);
+      return {
+        ingredients: display,
+        count: { count: display.length },
+      };
+    },
+    async findById(id: string) {
+      const ing = state.ingredients.find(
+        (i) => i.id === id && i.userId === userId,
+      );
+      if (!ing) return undefined;
+      return toIngredientDisplay(ing);
+    },
+    async create(ingredient: Ingredient) {
+      state.ingredients.push(ingredient);
+      return { id: ingredient.id };
+    },
+    async update(ingredient: Ingredient) {
+      const idx = requireOwnedIndex(
+        state.ingredients,
+        ingredient.id,
+        userId,
+        "Ingredient",
+      );
+      state.ingredients[idx] = ingredient;
+      return { id: ingredient.id };
+    },
+    async delete(id: string) {
+      const idx = requireOwnedIndex(
+        state.ingredients,
+        id,
+        userId,
+        "Ingredient",
+      );
+      state.ingredients.splice(idx, 1);
+    },
+    async getIngredientAnalytics(uId: string): Promise<IngredientAnalytics> {
+      const userIngredients = state.ingredients.filter((i) => i.userId === uId);
+      return {
+        totalIngredients: userIngredients.length,
+      };
+    },
+    async getHighImpactIngredients(
+      uId: string,
+      limit: number = 5,
+    ): Promise<HighImpactIngredient[]> {
+      const userIngredients = state.ingredients.filter((i) => i.userId === uId);
+      return userIngredients.slice(0, limit).map((i) => ({
+        id: i.id,
+        name: i.name,
+        icon: i.icon ?? null,
+        usage: Number(i.usage) || 0,
+        category: i.category,
+      }));
+    },
+  });

--- a/apps/api/src/testing/recipeFakes.ts
+++ b/apps/api/src/testing/recipeFakes.ts
@@ -1,0 +1,140 @@
+import type { Recipe, RecipeIngredients } from "@costwise/shared/recipe";
+import type {
+  RecipeWithQuery,
+  Metadata,
+} from "@costwise/shared/specialTypes";
+import type {
+  CreateRequest,
+  CreateResponse,
+} from "@costwise/domain/types/services";
+import type {
+  RecipeAnalytics,
+  CategoryAnalytics,
+  MarginHighlights,
+} from "@costwise/domain/types/repositories";
+import { NotFoundError } from "@costwise/domain/utils/errors";
+import type { Deps, RecipeServiceLike } from "../app";
+import { FakeState, getState, requireOwnedIndex } from "./state";
+
+/** The row shape the detail query returns — scalars stringified, no ingredients. */
+const toRecipeDetail = (recipe: Recipe): RecipeWithQuery => ({
+  id: recipe.id,
+  title: recipe.title,
+  totalCost: String(recipe.totalCost),
+  createdBy: recipe.createdBy,
+  dateCreated: recipe.dateCreated.toISOString(),
+  category: recipe.category,
+  tax: String(recipe.tax),
+  imgPath: recipe.imgPath,
+  sellingPrice: String(recipe.sellingPrice ?? 0),
+  profitMargin: String(recipe.profitMargin ?? 0),
+  foodCost: String(recipe.foodCost),
+  userId: recipe.userId,
+  recipeIngredients: [],
+});
+
+export const seedRecipe = (
+  deps: Deps,
+  userId: string,
+  recipe?: Partial<Recipe>,
+  detail?: Partial<RecipeWithQuery>,
+) => {
+  const r: Recipe = {
+    id: recipe?.id ?? "11111111-1111-1111-1111-111111111111",
+    title: recipe?.title ?? "Test Recipe",
+    totalCost: recipe?.totalCost ?? 10,
+    createdBy: recipe?.createdBy ?? userId,
+    dateCreated: recipe?.dateCreated ?? new Date(),
+    category: recipe?.category ?? "main",
+    tax: recipe?.tax ?? 0.1,
+    imgPath: recipe?.imgPath ?? "https://example.com/r1.jpg",
+    sellingPrice: recipe?.sellingPrice ?? 15,
+    profitMargin: recipe?.profitMargin ?? 5,
+    foodCost: recipe?.foodCost ?? 8,
+    userId,
+    ...recipe,
+  };
+  const d: RecipeWithQuery = { ...toRecipeDetail(r), ...detail };
+  const state = getState(deps);
+  state.recipes.push(r);
+  state.recipeDetails.set(r.id, d);
+  return r;
+};
+
+export const makeRecipeServiceFor =
+  (state: FakeState) =>
+  (userId: string): RecipeServiceLike => ({
+    async findAll(uId: string, metadata: Metadata) {
+      const userRecipes = state.recipes.filter((r) => r.userId === uId);
+      return {
+        recipes: userRecipes,
+        count: { count: userRecipes.length },
+      };
+    },
+    async findById(id: string) {
+      const detail = state.recipeDetails.get(id);
+      if (!detail || detail.userId !== userId) {
+        throw new NotFoundError("Recipe", id);
+      }
+      return detail;
+    },
+    async create(request: CreateRequest): Promise<CreateResponse> {
+      state.recipes.push(request.recipe);
+      state.recipeDetails.set(request.recipe.id, {
+        ...toRecipeDetail(request.recipe),
+        recipeIngredients: (request.addedIngredients || []).map((ing, idx) => ({
+          id: idx + 1,
+          recipeId: request.recipe.id,
+          ingredientId: ing.ingredientId,
+          quantity: String(ing.quantity),
+          ingredients: {
+            id: ing.ingredientId,
+            name: ing.name,
+            unit: ing.unit,
+            unitPrice: String(ing.unitPrice),
+            quantity: String(ing.quantity),
+            icon: null,
+            usage: "",
+          },
+        })),
+      });
+      return { recipe: request.recipe.id };
+    },
+    async update(
+      id: string,
+      recipe: Recipe,
+      _removed: RecipeIngredients[],
+      _added: RecipeIngredients[],
+    ) {
+      const idx = requireOwnedIndex(state.recipes, id, userId, "Recipe");
+      state.recipes[idx] = recipe;
+      return { id };
+    },
+    async delete(id: string) {
+      const idx = requireOwnedIndex(state.recipes, id, userId, "Recipe");
+      state.recipes.splice(idx, 1);
+      state.recipeDetails.delete(id);
+      return { id };
+    },
+    async getRecipesAnalytics(uId: string): Promise<RecipeAnalytics> {
+      const userRecipes = state.recipes.filter((r) => r.userId === uId);
+      return {
+        avgProfitMargin: "25",
+        avgFoodCost: "15",
+        totalRecipes: userRecipes.length,
+      };
+    },
+    async getCategoryAnalytics(uId: string): Promise<CategoryAnalytics[]> {
+      return [
+        { category: "starter", count: 1, avgFoodCost: "10" },
+        { category: "main", count: 2, avgFoodCost: "20" },
+      ];
+    },
+    async getMarginHighlights(uId: string): Promise<MarginHighlights> {
+      const userRecipes = state.recipes.filter((r) => r.userId === uId);
+      return {
+        topPerformers: userRecipes,
+        attentionNeeded: [],
+      };
+    },
+  });

--- a/apps/api/src/testing/state.ts
+++ b/apps/api/src/testing/state.ts
@@ -1,0 +1,47 @@
+import type { Recipe, Ingredient, Supplier } from "@costwise/shared/recipe";
+import type { RecipeWithQuery } from "@costwise/shared/specialTypes";
+import { NotFoundError } from "@costwise/domain/utils/errors";
+import type { Deps } from "../app";
+
+/**
+ * The in-memory store the fake services read and write. Each aggregate owns its
+ * own slice; the per-aggregate fake modules take this whole object so the seed
+ * helpers and the services share one source of truth.
+ */
+export interface FakeState {
+  recipes: Recipe[];
+  recipeDetails: Map<string, RecipeWithQuery>;
+  ingredients: Ingredient[];
+  suppliers: Supplier[];
+  uploadedBlobs: Map<string, { name: string; body: any }>;
+}
+
+export const createFakeState = (): FakeState => ({
+  recipes: [],
+  recipeDetails: new Map(),
+  ingredients: [],
+  suppliers: [],
+  uploadedBlobs: new Map(),
+});
+
+/** The seed helpers reach the state that `fakeDeps()` stashed on the deps. */
+export const getState = (deps: Deps): FakeState => (deps as any)._state;
+
+/**
+ * Locates an owned row or throws the same NotFoundError the real services do.
+ * Every update/delete on every aggregate needs exactly this.
+ */
+export const requireOwnedIndex = <T extends { id: string; userId: string }>(
+  items: T[],
+  id: string,
+  userId: string,
+  resource: string,
+): number => {
+  const idx = items.findIndex(
+    (item) => item.id === id && item.userId === userId,
+  );
+  if (idx === -1) {
+    throw new NotFoundError(resource, id);
+  }
+  return idx;
+};

--- a/apps/api/src/testing/supplierFakes.ts
+++ b/apps/api/src/testing/supplierFakes.ts
@@ -1,0 +1,75 @@
+import type { Supplier } from "@costwise/shared/recipe";
+import type { Metadata } from "@costwise/shared/specialTypes";
+import type { SupplierUpdatePayload } from "@costwise/shared/uiTypes";
+import type { Deps, SupplierServiceLike } from "../app";
+import { FakeState, getState, requireOwnedIndex } from "./state";
+
+export const seedSupplier = (
+  deps: Deps,
+  userId: string,
+  supplier?: Partial<Supplier>,
+) => {
+  const s: Supplier = {
+    id: supplier?.id ?? "66666666-6666-6666-6666-666666666666",
+    userId,
+    name: supplier?.name ?? "Acme Supplier",
+    icon: supplier?.icon ?? null,
+    category: supplier?.category ?? ["5dee106a-5050-443e-8368-03397e02af6d"],
+    contactPerson: supplier?.contactPerson ?? "John Doe",
+    email: supplier?.email ?? "acme@example.com",
+    phone: supplier?.phone ?? "1234567890",
+    website: supplier?.website ?? "https://acme.com",
+    address: supplier?.address ?? {
+      street: "123 Main St",
+      city: "City",
+      state: "State",
+      postalCode: "12345",
+      country: "Country",
+    },
+    financialData: supplier?.financialData ?? {
+      paymentTerms: "Net 30",
+      vatNumber: "VAT123",
+    },
+    notes: supplier?.notes ?? "Test notes",
+    deliveryTime: supplier?.deliveryTime ?? "1-2 Days",
+    isActive: supplier?.isActive ?? true,
+    dateAdded: supplier?.dateAdded ?? new Date(),
+    ...supplier,
+  };
+  getState(deps).suppliers.push(s);
+  return s;
+};
+
+export const makeSupplierServiceFor =
+  (state: FakeState) =>
+  (userId: string): SupplierServiceLike => ({
+    async findAll(uId: string, metadata: Metadata) {
+      const userSuppliers = state.suppliers.filter((s) => s.userId === uId);
+      return {
+        suppliers: userSuppliers,
+        count: { count: userSuppliers.length },
+      };
+    },
+    async findById(id: string) {
+      return state.suppliers.find((s) => s.id === id && s.userId === userId);
+    },
+    async create(payload: SupplierUpdatePayload) {
+      state.suppliers.push(payload.supplier);
+      return { id: payload.supplier.id };
+    },
+    async update(payload: SupplierUpdatePayload) {
+      const idx = requireOwnedIndex(
+        state.suppliers,
+        payload.supplier.id,
+        userId,
+        "Supplier",
+      );
+      state.suppliers[idx] = payload.supplier;
+      return { id: payload.supplier.id };
+    },
+    async delete(id: string) {
+      const idx = requireOwnedIndex(state.suppliers, id, userId, "Supplier");
+      state.suppliers.splice(idx, 1);
+      return { id };
+    },
+  });

--- a/apps/web/src/app/components/recipes/recipeForm/recipeForm.tsx
+++ b/apps/web/src/app/components/recipes/recipeForm/recipeForm.tsx
@@ -11,11 +11,8 @@ import {
   Plus,
   Sparkles,
 } from 'lucide-react';
-import { Recipe, RecipeCategory, Ingredient, IngredientToDisplay, RecipeIngredients, RecipeSchema } from '@costwise/shared/recipe';
-import { z } from 'zod';
+import { Recipe, RecipeCategory, Ingredient, IngredientToDisplay, RecipeIngredients } from '@costwise/shared/recipe';
 import useRecipeForm from '@/app/hooks/useRecipeForm';
-
-export type FormFields = z.infer<typeof RecipeSchema>;
 import { Input } from '../../ui/input';
 import { MoneyInput } from '../../ui/moneyInput';
 import { Button } from '../../ui/button';

--- a/apps/web/src/app/constants/recipeFormDefaultValues.ts
+++ b/apps/web/src/app/constants/recipeFormDefaultValues.ts
@@ -3,7 +3,7 @@
  * - Matches the `FormFields` type to ensure type safety and consistent form state initialization.
  * - Includes placeholder values for all recipe properties, including metadata, pricing, and image URL.
  */
-import { FormFields } from "../hooks/useRecipeForm"
+import { FormFields } from "@costwise/shared/recipe"
 
 export const defaultValues: FormFields = {
     

--- a/apps/web/src/app/hooks/useRecipeForm.tsx
+++ b/apps/web/src/app/hooks/useRecipeForm.tsx
@@ -13,10 +13,9 @@
  */
 "use client"
 import { useCallback, useState } from 'react';
-import { RecipeIngredients, RecipeSchema } from '@costwise/shared/recipe';
+import { FormFields, RecipeIngredients, RecipeSchema } from '@costwise/shared/recipe';
 import { v4 as uuidv4 } from "uuid";
 import { useForm } from 'react-hook-form';
-import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { calculateRecipeData, getTotalPrice } from '@costwise/shared/pricing';
 import { getArrayChanges } from '@costwise/shared/transformers';
@@ -29,7 +28,6 @@ import { RecipeFormProps } from '../components/recipes/recipeForm/recipeForm';
 import { useFileStore } from '../stores/fileStore';
 import { useNotificationStore } from '../stores/notificationStore';
 
-export type FormFields = z.infer<typeof RecipeSchema>;
 
 const useRecipeForm = ({mode, recipe, recipeIngredients, userId}: RecipeFormProps) => {
   const [newId, setNewId] = useState<string>(() => uuidv4());

--- a/apps/web/src/app/services/services.ts
+++ b/apps/web/src/app/services/services.ts
@@ -3,7 +3,7 @@
  * Uses @costwise/api-client (apiBrowser) to communicate with the Backend API.
  */
 
-import { FormFields } from "../components/recipes/recipeForm/recipeForm";
+import { FormFields } from "@costwise/shared/recipe";
 import {
   Ingredient,
   IngredientCategory,

--- a/apps/web/src/app/utils/pagination.test.ts
+++ b/apps/web/src/app/utils/pagination.test.ts
@@ -1,4 +1,3 @@
-import { describe, test, expect } from "@jest/globals";
 import { paginationPages } from "./pagination";
 
 describe("paginationPages", () => {

--- a/packages/shared/src/pricing.ts
+++ b/packages/shared/src/pricing.ts
@@ -1,6 +1,4 @@
-import { Recipe, RecipeIngredients, Unit } from "./recipe";
-
-export type FormFields = Recipe;
+import { FormFields, Recipe, RecipeIngredients, Unit } from "./recipe";
 
 export const getTotalPrice = (ingredients: RecipeIngredients[]): number => {
   return ingredients.reduce((sum, item) => {

--- a/packages/shared/src/recipe.ts
+++ b/packages/shared/src/recipe.ts
@@ -137,6 +137,13 @@ export const RecipeSchema = z.object({
 
 export type Recipe = z.infer<typeof RecipeSchema>;
 
+/**
+ * Recipe form values — the schema-inferred shape react-hook-form binds to.
+ * Canonical home for `FormFields`; the web app and `pricing.ts` import it here
+ * rather than each re-deriving it from `RecipeSchema`.
+ */
+export type FormFields = Recipe;
+
 // Schema for the db recipe object
 export const DBRecipeSchema = z.object({
   id: z.string().uuid(),


### PR DESCRIPTION
Closes four Fallow follow-ups. One commit each.

## Fallow A — `@jest/globals` (`868kvw0ft`)
`pagination.test.ts` imported `describe`/`test`/`expect` from `@jest/globals`, which is not in `apps/web/package.json` and not in `apps/web/node_modules` — it resolved only through pnpm root hoisting, one node-linker change from breaking. Every sibling test uses the injected globals typed by `@types/jest`, which *is* declared. Dropped the import.

Fallow unlisted dependencies: **1 → 0**.

## Fallow B — barrel cycle (`868kvw0q2`) — no code change
`apps/web/src/app/constants/components.ts` no longer exists on `main`; Task 4.5’s orphan-cluster deletion took it with the components that imported back from it. Verified: the file is absent from `origin/main`, nothing imports `constants/components`, and `fallow dead-code` reports no cycle involving it. Closing as verified rather than leaving it open against a file that is gone.

## Fallow D — one home for `FormFields` (`868kvw157`)
The type was derived **three** times from the same schema, not two — `recipeForm.tsx`, `useRecipeForm.tsx`, and a third copy in `packages/shared/src/pricing.ts` the finding did not list. All three are just `Recipe`. It now lives once in `packages/shared/src/recipe.ts` beside `RecipeSchema` and `Recipe`.

**This collapses most of Fallow C as a side effect.** `services.ts` and `recipeFormDefaultValues.ts` were importing `FormFields` from the UI component they serve — the layering inversion C describes. Pointing them at `shared` removes those back edges:

- circular dependencies **7 → 1**
- duplicate exports **1 → 0**

The one survivor is `useRecipeForm.tsx` importing `RecipeFormProps` from `recipeForm.tsx`. Left for Fallow C, which owns it — but C is now a single type move, not a session of work.

## Fallow I — split the API test fakes (`868kvw2hr`)
`fakes.ts` was the repo’s top churn hotspot: 396 LOC, 7 dependents, 417 lines churned over 7 commits, so every schema change rippled through all five API suites at once.

Aggregates now own their own files (`recipeFakes`, `ingredientFakes`, `supplierFakes`) over a shared `state` module. `fakes.ts` stays the entry point and re-exports them, so **no test file changed**.

Clones folded:
- the `findIndex` / `NotFoundError` pair in every update and delete → `requireOwnedIndex()`
- the recipe detail row built in both `seedRecipe` and `create` → `toRecipeDetail()`
- the suppliers-stripping display mapping used by ingredients and search → `toIngredientDisplay()`

## Verification

- `pnpm build`, `pnpm test` (129 tests), `pnpm lint` — green
- `pnpm --filter api test` — 80 tests, no assertion touched
- `fallow`: circular deps 7 → 1, duplicate pairs 1 → 0, unlisted deps 1 → 0, duplication 7.4% → 7.2%

🤖 Generated with [Claude Code](https://claude.com/claude-code)