### PR TITLE
chore(web): Fallow C — break the last recipe-form import cycle (868kvw0z3)

### DIFF
--- a/apps/web/src/app/components/recipes/recipeForm/recipeForm.tsx
+++ b/apps/web/src/app/components/recipes/recipeForm/recipeForm.tsx
@@ -11,7 +11,7 @@ import {
   Plus,
   Sparkles,
 } from 'lucide-react';
-import { Recipe, RecipeCategory, Ingredient, IngredientToDisplay, RecipeIngredients } from '@costwise/shared/recipe';
+import { RecipeCategory } from '@costwise/shared/recipe';
 import useRecipeForm from '@/app/hooks/useRecipeForm';
 import { Input } from '../../ui/input';
 import { MoneyInput } from '../../ui/moneyInput';
@@ -24,14 +24,7 @@ import { useFileStore } from '@/app/stores/fileStore';
 import { useNotificationStore } from '@/app/stores/notificationStore';
 import { CategoryThumbnail } from '@/app/utils/uiHelpers';
 import { calculateProfitMargin, calculateSellingPrice, formatPrice, getTotalPrice } from '@costwise/shared/pricing';
-
-export interface RecipeFormProps {
-  mode: 'create' | 'edit';
-  ingredients: (Ingredient | IngredientToDisplay)[];
-  recipe?: Recipe;
-  recipeIngredients: RecipeIngredients[];
-  userId: string;
-}
+import { RecipeFormProps } from './types';
 
 export default function RecipeForm({
   ingredients,

--- a/apps/web/src/app/components/recipes/recipeForm/types.ts
+++ b/apps/web/src/app/components/recipes/recipeForm/types.ts
@@ -1,0 +1,24 @@
+import {
+  Ingredient,
+  IngredientToDisplay,
+  Recipe,
+  RecipeIngredients,
+} from '@costwise/shared/recipe';
+
+/**
+ * Inputs to the recipe form — the component's props and, identically, the
+ * arguments `useRecipeForm` takes.
+ *
+ * It lives here rather than in `recipeForm.tsx` so the hook can name its own
+ * parameter type without importing from the component that consumes it. That
+ * import was the last back edge in the recipeForm ↔ hooks ↔ services cycle and
+ * a layering inversion against the documented order (UI → hooks/stores →
+ * services). Keep this module free of imports from `components/` and `hooks/`.
+ */
+export interface RecipeFormProps {
+  mode: 'create' | 'edit';
+  ingredients: (Ingredient | IngredientToDisplay)[];
+  recipe?: Recipe;
+  recipeIngredients: RecipeIngredients[];
+  userId: string;
+}

--- a/apps/web/src/app/hooks/useRecipeForm.tsx
+++ b/apps/web/src/app/hooks/useRecipeForm.tsx
@@ -24,7 +24,7 @@ import { useRouter } from 'next/navigation';
 import { useFileUpload } from './useFileUpload';
 import useHelpers from './useHelpers';
 import { defaultValues } from '../constants/recipeFormDefaultValues';
-import { RecipeFormProps } from '../components/recipes/recipeForm/recipeForm';
+import { RecipeFormProps } from '../components/recipes/recipeForm/types';
 import { useFileStore } from '../stores/fileStore';
 import { useNotificationStore } from '../stores/notificationStore';
 


### PR DESCRIPTION
⚠️ **Stacked on [#174](https://github.com/st9ho3/costwise/pull/174)** — based on `chore/fallow-abdi-sweep`, not `main`. Merge #174 first; this PR will retarget to `main` automatically.

Closes Fallow C (`868kvw0z3`) — https://app.clickup.com/t/868kvw0z3

## What was left

The card describes seven cycles and calls this "the highest-risk cycle set in the repo". Six of them, plus the `services/` → `components/` import, were already removed by **Fallow D** in #174: `services.ts` and `recipeFormDefaultValues.ts` had been importing `FormFields` from the UI component they serve, and pointing them at `@costwise/shared/recipe` dissolved those edges.

That left exactly one:

```
recipeForm.tsx → hooks/useRecipeForm.tsx → recipeForm.tsx
```

`RecipeFormProps` was declared in `recipeForm.tsx` and imported by `useRecipeForm.tsx` — the hook depending on the component that consumes it, against the documented layer order (UI → hooks/stores → services).

## What changed

The interface moves to a sibling `types.ts` that imports only from `@costwise/shared/recipe`. Both the component and the hook now depend on it, and neither depends on the other. `Recipe`, `Ingredient`, `IngredientToDisplay` and `RecipeIngredients` went unused in `recipeForm.tsx` once the interface left, so that import narrows to `RecipeCategory`.

**Fallow now reports 0 circular dependencies repo-wide, down from 7 on `main`.**

## Acceptance criteria

| Criterion | Result |
|---|---|
| 0 circular deps under `components/recipes/**` and `hooks/**` | 0 repo-wide ✅ |
| No module under `services/` imports from `components/` | verified by grep ✅ |
| Shared form types in one place | `RecipeFormProps` → `types.ts`; `FormFields` → `@costwise/shared/recipe` ✅ |
| `pnpm build` / `pnpm test` (129) / `pnpm lint` | green ✅ |

## On "recipe create/edit verified working"

Being straight about this one. The change is a **type-only move** — `RecipeFormProps` is erased at build time and no runtime code was touched. What was actually verified:

- the production build compiles the recipe create and edit routes
- `useRecipeForm.test.tsx` covers create-mode and edit-mode submission, and both pass

What was **not** done: a signed-in browser click-through, which needs credentials I should not enter. Worth a quick manual pass before merge if you want the criterion fully closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)